### PR TITLE
Update android-sdk-license acceptance

### DIFF
--- a/main.go
+++ b/main.go
@@ -74,7 +74,7 @@ func (configs ConfigsModel) validate() error {
 // EnsureAndroidLicences ...
 func EnsureAndroidLicences(androidHome string) error {
 	licenceMap := map[string]string{
-		"android-sdk-license":         "\n8933bad161af4178b1185d1a37fbf41ea5269c55",
+		"android-sdk-license":         "\n8933bad161af4178b1185d1a37fbf41ea5269c55\nd56f5187479451eabf01fb78af6dfcb131a6481e",
 		"android-sdk-preview-license": "\n84831b9409646a918e30573bab4c9c91346d8abd",
 		"intel-android-extra-license": "\nd975f751698a77b662f1254ddbeed3901e976f5a",
 	}


### PR DESCRIPTION
This step is failing since Google changed the license:

```
A problem occurred configuring project ':app'.
> You have not accepted the license agreements of the following SDK components:
  [Android SDK Build-Tools 26].
  Before building your project, you need to accept the license agreements and complete the installation of the missing components using the Android Studio SDK Manager.
  Alternatively, to learn how to transfer the license agreements from one workstation to another, go to http://d.android.com/r/studio-ui/export-licenses.html
```

This adds the hash for the acceptance of the new license.