### PR TITLE
Fix NDK version for CI testing

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -106,8 +106,12 @@ workflows:
             rm -rf $ANDROID_HOME/ndk-bundle
     - path::./:
         title: Step test installing ndk
+        inputs:
+        - ndk_revision: "21"
     - path::./:
         title: Step test installed ndk
+        inputs:
+        - ndk_revision: "21"
 
   test_react_native:
     envs:


### PR DESCRIPTION
Fix ndk version as starting at 22 they deprecated mechanism which is not compatible with our old sample app