### PR TITLE
Install Android NDK to `$sdk/ndk-bundle`

### DIFF
--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -37,11 +37,16 @@ workflows:
             #!/usr/bin/env bash
             set -ex
             yarn
-    after_run:
-    - _run_and_build
+    - path::./:
+        title: Execute step
+        inputs:
+          - ndk_revision: 21
+    - gradle-runner:
+        inputs:
+        - gradle_task: assembleDebug
 
   test_ndk_install:
-    summary: Test installing multiple NDK revisions
+    summary: Test installing multiple NDK revisions and compare installed version numbers to expected values
     envs:
     - SAMPLE_APP_URL: https://github.com/bitrise-io/android-ndk-sample-project.git
     - BRANCH: ndk22-compatible
@@ -57,20 +62,72 @@ workflows:
     - path::./:
         title: Execute step with NDK r18
         inputs:
-        - ndk_revision: "18"
+        - ndk_revision: 18
+    - script:
+        title: Check installed NDK version
+        inputs:
+        - content: |-
+            EXPECTED_VERSION=18.0.5002713
+            NDK_VERSION=`cat $ANDROID_HOME/ndk-bundle/source.properties | grep Pkg.Revision | cut -d'=' -f2 | cut -d' ' -f2`
+            if [ $NDK_VERSION != $EXPECTED_VERSION ]; then
+              echo "Unexpected installed NDK version: $NDK_VERSION"
+              echo "Expected: $EXPECTED_VERSION"
+              exit 1
+            else
+              echo "NDK version is correct: $NDK_VERSION"
+            fi
     - path::./:
         title: Execute step again with NDK r18
         inputs:
-        - ndk_revision: "18"
+        - ndk_revision: 18
+    - script:
+        title: Check installed NDK version
+        inputs:
+        - content: |-
+            EXPECTED_VERSION=18.0.5002713
+            NDK_VERSION=`cat $ANDROID_HOME/ndk-bundle/source.properties | grep Pkg.Revision | cut -d'=' -f2 | cut -d' ' -f2`
+            if [ $NDK_VERSION != $EXPECTED_VERSION ]; then
+              echo "Unexpected installed NDK version: $NDK_VERSION"
+              echo "Expected: $EXPECTED_VERSION"
+              exit 1
+            else
+              echo "NDK version is correct: $NDK_VERSION"
+            fi
     - path::./:
         title: Execute step with NDK r17
         inputs:
-        - ndk_revision: "17"
+        - ndk_revision: 17
+    - script:
+        title: Check installed NDK version
+        inputs:
+        - content: |-
+            EXPECTED_VERSION=17.0.4754217
+            NDK_VERSION=`cat $ANDROID_HOME/ndk-bundle/source.properties | grep Pkg.Revision | cut -d'=' -f2 | cut -d' ' -f2`
+            if [ $NDK_VERSION != $EXPECTED_VERSION ]; then
+              echo "Unexpected installed NDK version: $NDK_VERSION"
+              echo "Expected: $EXPECTED_VERSION"
+              exit 1
+            else
+              echo "NDK version is correct: $NDK_VERSION"
+            fi
     - path::./:
         title: Execute step with NDK r22
         description: NDK r22 doesn't contain the platforms dir anymore
         inputs:
-        - ndk_revision: "22"
+        - ndk_revision: 22
+    - script:
+        title: Check installed NDK version
+        inputs:
+        - content: |-
+            EXPECTED_VERSION=22.0.7026061
+            NDK_VERSION=`cat $ANDROID_HOME/ndk-bundle/source.properties | grep Pkg.Revision | cut -d'=' -f2 | cut -d' ' -f2`
+            if [ $NDK_VERSION != $EXPECTED_VERSION ]; then
+              echo "Unexpected installed NDK version: $NDK_VERSION"
+              echo "Expected: $EXPECTED_VERSION"
+              exit 1
+            else
+              echo "NDK version is correct: $NDK_VERSION"
+            fi
     - gradle-runner:
         inputs:
         - gradle_task: assembleDebug

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -119,7 +120,7 @@ func updateNDK(revision string) error {
 	}
 
 	var unzippedDirName string
-	dirs, err := os.ReadDir(unzipTarget)
+	dirs, err := ioutil.ReadDir(unzipTarget)
 	for _, dir := range dirs {
 		if subDirPattern.MatchString(dir.Name()) {
 			unzippedDirName = dir.Name()


### PR DESCRIPTION
### Checklist

- [X] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _PATCH_ [version update](https://semver.org/)

### Context

In recent Android Gradle Plugin versions, using `$ANDROID_NDK_HOME` to point to the NDK dir is deprecated and removed, AGP looks at the new default install location to find the NDK. Details: https://github.com/android/ndk-samples/wiki/Configure-NDK-Path

Part of https://bitrise.atlassian.net/browse/STEP-247 

### Changes

- NDK install location:
    - Change from `$sdk/android-ndk-bundle` to `$sdk/ndk-bundle`. This is the new default location when NDK is not installed side-by-side (in a version number dir)
    - `$ANDROID_NDK_HOME` is still set and points to the new location (compatibility for old AGP versions)
 - E2E test: add extra checks that verify the installed NDK version
 - Make logs more informative

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

- Install to `$sdk/ndk-bundle` dir instead of `$sdk/$ndk-version`: The step's input only specify the major NDK version, but this versioned install location would require the full version code (see Google doc for details). Changing this input would be a breaking change
