### PR TITLE
Test running on JDK11

### DIFF
--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -132,20 +132,6 @@ workflows:
         inputs:
         - gradle_task: assembleDebug
 
-  test_android-sdk21-tools-21.0.1:
-    envs:
-    - SAMPLE_APP_URL: https://github.com/bitrise-io/android-sdk21-tools-21.0.1.git
-    - BRANCH: master
-    - GRADLE_BUILD_FILE_PATH: build.gradle
-    - GRADLEW_PATH: ./gradlew
-    before_run:
-    - _setup
-    steps:
-    - path::./:
-        title: Execute step
-    # Not executing any Gradle build in this test because the SDK version used in this repo has a known issue and
-    # crashes the Gradle build (the issue is fixed in later SDK versions though)
-
   test_support_library:
     envs:
     - SAMPLE_APP_URL: https://github.com/bitrise-io/sample-apps-android-x.git

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -160,6 +160,7 @@ workflows:
     - _setup
     after_run:
     - _run_and_build
+    - _restore_build_tools
     steps:
     - script:
         title: Remove preinstalled SDK build-tools
@@ -167,7 +168,7 @@ workflows:
         - content: |-
             #!/usr/bin/env bash
             set -ex
-            rm -rf $ANDROID_HOME/build-tools
+            mv $ANDROID_HOME/build-tools $ANDROID_HOME/build-tools-original
 
   _setup:
     steps:
@@ -213,3 +214,13 @@ workflows:
     - gradle-runner:
         inputs:
         - gradle_task: assembleDebug
+  _restore_build_tools:
+    steps:
+    - script:
+        title: Restore preinstalled SDK build-tools
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -ex
+            rm -rf $ANDROID_HOME/build-tools
+            mv $ANDROID_HOME/build-tools-original $ANDROID_HOME/build-tools

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -150,6 +150,23 @@ workflows:
     after_run:
     - _run_and_build
 
+  test_build_tools_not_installed:
+    envs:
+    - SAMPLE_APP_URL: https://github.com/bitrise-io/Bitrise-Android-Sample.git
+    - BRANCH: main
+    before_run:
+    - _setup
+    after_run:
+    - _run_and_build
+    steps:
+    - script:
+        title: Remove preinstalled SDK build-tools
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            set -ex
+            rm -rf $ANDROID_HOME/build-tools
+
   _setup:
     steps:
     - script:

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -154,6 +154,8 @@ workflows:
     envs:
     - SAMPLE_APP_URL: https://github.com/bitrise-io/Bitrise-Android-Sample.git
     - BRANCH: main
+    - GRADLE_BUILD_FILE_PATH: build.gradle
+    - GRADLEW_PATH: ./gradlew
     before_run:
     - _setup
     after_run:

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -150,32 +150,6 @@ workflows:
     after_run:
     - _run_and_build
 
-  test_android-sdk20:
-    summary: Test installing SDK platform 20 (not preinstalled on stacks)
-    envs:
-    - SAMPLE_APP_URL: https://github.com/bitrise-io/sample-apps-android-sdk20.git
-    - BRANCH: master
-    - GRADLE_BUILD_FILE_PATH: build.gradle
-    - GRADLEW_PATH: ./gradlew
-    before_run:
-    - _setup
-    steps:
-    - path::./:
-        title: Execute step
-    # Not executing any Gradle build in this test because the SDK version used in this repo has a known issue and
-    # crashes the Gradle build (the issue is fixed in later SDK versions though)
-
-  test_android-sdk22-subdir:
-    envs:
-    - SAMPLE_APP_URL: https://github.com/bitrise-io/sample-apps-android-sdk22-subdir.git
-    - BRANCH: master
-    - GRADLE_BUILD_FILE_PATH: src/build.gradle
-    - GRADLEW_PATH: src/gradlew
-    before_run:
-    - _setup
-    after_run:
-    - _run_and_build
-
   _setup:
     steps:
     - script:

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -204,6 +204,22 @@ workflows:
   _setup:
     steps:
     - script:
+          run_if: $.IsCI
+          inputs:
+            - content: |-
+                #!/usr/bin/env bash
+                set -ex
+                if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+                  sudo update-alternatives --set javac /usr/lib/jvm/java-11-openjdk-amd64/bin/javac
+                  sudo update-alternatives --set java /usr/lib/jvm/java-11-openjdk-amd64/bin/java
+                  export JAVA_HOME="/usr/lib/jvm/java-11-openjdk-amd64"
+                  envman add --key JAVA_HOME --value "/usr/lib/jvm/java-11-openjdk-amd64"
+                elif [[ "$OSTYPE" == "darwin"* ]]; then
+                  jenv global 11
+                  export JAVA_HOME="$(jenv prefix)"
+                  envman add --key JAVA_HOME --value "$(jenv prefix)"
+                fi
+    - script:
         title: Clean _tmp dir
         inputs:
         - content: |-

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -164,17 +164,6 @@ workflows:
     after_run:
     - _run_and_build
 
-  test_old_gradle:
-    envs:
-    - SAMPLE_APP_URL: https://github.com/bitrise-io/2048-android.git
-    - BRANCH: master
-    - GRADLE_BUILD_FILE_PATH: build.gradle
-    - GRADLEW_PATH: ./gradlew
-    before_run:
-    - _setup
-    after_run:
-    - _run_and_build
-
   test_android-sdk20:
     summary: Test installing SDK platform 20 (not preinstalled on stacks)
     envs:


### PR DESCRIPTION
### Checklist

- [X] I've read and accepted the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- Requires _NO_ [version update](https://semver.org/)

### Context

<!--- One sentence summary on why the change is needed. -->

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.
-->

### Changes
- Remove some E2E tests that are using very old Gradle versions on purpose. Because of the JDK 11 upgrade, projects with old Gradle versions won't run anymore, and upgrading the Gradle/AGP version in the project would defeat the test's purpose.
- Add a new E2E test that nukes `$ANDROID_HOME/build-tools/*` before build to simulate a scenario when the requested build-tools version is not available and needs to be downloaded

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

CI fails on the VSCode stack because the outdated preinstalled SDK doesn't run on JDK 11. This will be addressed on the infra side.
