### PR TITLE
Use `sdkmanager` to install NDK, require exact version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,87 +1,69 @@
-# Install missing Android tools
+# Install missing Android SDK components
 
-This step analyze your root settings.gradle file, to collect the active build.gradle files.
+[![Step changelog](https://shields.io/github/v/release/bitrise-steplib/steps-install-missing-android-tools?include_prereleases&label=changelog&color=blueviolet)](https://github.com/bitrise-steplib/steps-install-missing-android-tools/releases)
 
-Based on the build.gradle files it will:
+Install Android SDK components that are required for the app.
 
-- install required `compileSdkVersion`s if missing
-- install required `buildToolsVersion`s if missing
-- update `Support Library` if used
-- update `Google Play Services` if used
-
-## How to use this Step
-
-Can be run directly with the [bitrise CLI](https://github.com/bitrise-io/bitrise),
-just `git clone` this repository, `cd` into it's folder in your Terminal/Command Line
-and call `bitrise run test`.
-
-*Check the `bitrise.yml` file for required inputs which have to be
-added to your `.bitrise.secrets.yml` file!*
-
-Step by step:
-
-1. Open up your Terminal / Command Line
-2. `git clone` the repository
-3. `cd` into the directory of the step (the one you just `git clone`d)
-5. Create a `.bitrise.secrets.yml` file in the same directory of `bitrise.yml` - the `.bitrise.secrets.yml` is a git ignored file, you can store your secrets in
-6. Check the `bitrise.yml` file for any secret you should set in `.bitrise.secrets.yml`
-  * Best practice is to mark these options with something like `# define these in your .bitrise.secrets.yml`, in the `app:envs` section.
-7. Once you have all the required secret parameters in your `.bitrise.secrets.yml` you can just run this step with the [bitrise CLI](https://github.com/bitrise-io/bitrise): `bitrise run test`
-
-An example `.bitrise.secrets.yml` file:
-
-```
-envs:
-- A_SECRET_PARAM_ONE: the value for secret one
-- A_SECRET_PARAM_TWO: the value for secret two
-```
-
-## How to create your own step
-
-1. Create a new git repository for your step (**don't fork** the *step template*, create a *new* repository)
-2. Copy the [step template](https://github.com/bitrise-steplib/step-template) files into your repository
-3. Fill the `step.sh` with your functionality
-4. Wire out your inputs to `step.yml` (`inputs` section)
-5. Fill out the other parts of the `step.yml` too
-6. Provide test values for the inputs in the `bitrise.yml`
-7. Run your step with `bitrise run test` - if it works, you're ready
-
-__For Step development guidelines & best practices__ check this documentation: [https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md).
-
-**NOTE:**
-
-If you want to use your step in your project's `bitrise.yml`:
-
-1. git push the step into it's repository
-2. reference it in your `bitrise.yml` with the `git::PUBLIC-GIT-CLONE-URL@BRANCH` step reference style:
-
-```
-- git::https://github.com/user/my-step.git@branch:
-   title: My step
-   inputs:
-   - my_input_1: "my value 1"
-   - my_input_2: "my value 2"
-```
-
-You can find more examples of step reference styles
-in the [bitrise CLI repository](https://github.com/bitrise-io/bitrise/blob/master/_examples/tutorials/steps-and-workflows/bitrise.yml#L65).
-
-## How to contribute to this Step
-
-1. Fork this repository
-2. `git clone` it
-3. Create a branch you'll work on
-4. To use/test the step just follow the **How to use this Step** section
-5. Do the changes you want to
-6. Run/test the step before sending your contribution
-  * You can also test the step in your `bitrise` project, either on your Mac or on [bitrise.io](https://www.bitrise.io)
-  * You just have to replace the step ID in your project's `bitrise.yml` with either a relative path, or with a git URL format
-  * (relative) path format: instead of `- original-step-id:` use `- path::./relative/path/of/script/on/your/Mac:`
-  * direct git URL format: instead of `- original-step-id:` use `- git::https://github.com/user/step.git@branch:`
-  * You can find more example of alternative step referencing at: https://github.com/bitrise-io/bitrise/blob/master/_examples/tutorials/steps-and-workflows/bitrise.yml
-7. Once you're done just commit your changes & create a Pull Request
+<details>
+<summary>Description</summary>
 
 
-## Share your own Step
+This Step makes sure that required Android SDK components (platforms and build-tools) are installed. To do so, the Step runs the `gradlew dependencies` command. 
 
-You can share your Step or step version with the [bitrise CLI](https://github.com/bitrise-io/bitrise). Just run `bitrise share` and follow the guide it prints.
+If the Android Plugin for Gradle version is 2.2.0 or higher, the plugin will download and install the missing components during the Gradle command.  
+Otherwise the command fails and the Step parses the command's output to determine which SDK components are missing and installs them.
+
+### Configuring the Step
+
+1. Set the path of the `gradlew` file.
+
+   The default value is that of the $PROJECT_LOCATION Environment Variable.
+
+1. If you use an Android NDK in your app, set its revision in the **NDK Revision** input.
+
+### Troubleshooting
+
+If the Step fails, check that your repo actually contains a `gradlew` file. Without the Gradle wrapper, this Step won't work.
+
+### Useful links
+
+[Installing an additional Android SDK package](https://devcenter.bitrise.io/tips-and-tricks/android-tips-and-tricks/#how-to-install-an-additional-android-sdk-package)
+
+### Related Steps
+
+* [Android SDK Update](https://www.bitrise.io/integrations/steps/android-sdk-update)
+* [Install React Native](https://www.bitrise.io/integrations/steps/install-react-native)
+</details>
+
+## 🧩 Get started
+
+Add this step directly to your workflow in the [Bitrise Workflow Editor](https://devcenter.bitrise.io/steps-and-workflows/steps-and-workflows-index/).
+
+You can also run this step directly with [Bitrise CLI](https://github.com/bitrise-io/bitrise).
+
+## ⚙️ Configuration
+
+<details>
+<summary>Inputs</summary>
+
+| Key | Description | Flags | Default |
+| --- | --- | --- | --- |
+| `gradlew_path` | Using a Gradle Wrapper (gradlew) is required, as the wrapper is what makes sure that the right Gradle version is installed and used for the build. __You can find more information about the Gradle Wrapper (gradlew), and about how you can generate one (if you would not have one already)__ in the official guide at: [https://docs.gradle.org/current/userguide/gradle_wrapper.html](https://docs.gradle.org/current/userguide/gradle_wrapper.html).  **The path should be relative** to the repository root, for example: `./gradlew`, or if it's in a sub directory: `./sub/dir/gradlew`.  | required | `$GRADLEW_PATH` |
+| `ndk_version` | NDK version to install, for example `23.0.7599858`. Run `sdkmanager --list` on your machine to see all available versions. Leave this input empty if you are not using the Native Development Kit in your project. |  |  |
+</details>
+
+<details>
+<summary>Outputs</summary>
+There are no outputs defined in this step
+</details>
+
+## 🙋 Contributing
+
+We welcome [pull requests](https://github.com/bitrise-steplib/steps-install-missing-android-tools/pulls) and [issues](https://github.com/bitrise-steplib/steps-install-missing-android-tools/issues) against this repository.
+
+For pull requests, work on your changes in a forked repository and use the Bitrise CLI to [run step tests locally](https://devcenter.bitrise.io/bitrise-cli/run-your-first-build/).
+
+Learn more about developing steps:
+
+- [Create your own step](https://devcenter.bitrise.io/contributors/create-your-own-step/)
+- [Testing your Step](https://devcenter.bitrise.io/contributors/testing-and-versioning-your-steps/)

--- a/androidcomponents/androidcomponents.go
+++ b/androidcomponents/androidcomponents.go
@@ -217,7 +217,6 @@ func (i installer) extrasLib(lib string) error {
 		if err != nil {
 			return fmt.Errorf("output: %s, error: %s", out, err)
 		}
-		return nil
 	}
 	return nil
 }

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -12,6 +12,10 @@ workflows:
         inputs:
         - workflow: e2e
 
+  generate_readme:
+    steps:
+    - git::https://github.com/bitrise-steplib/steps-readme-generator.git@main: {}
+
   sample:
     envs:
     - GRADLE_BUILD_FILE_PATH: build.gradle

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -40,7 +40,7 @@ workflows:
     - path::./:
         title: Execute step
         inputs:
-          - ndk_revision: 21
+          - ndk_version: 21.1.6352462
     - gradle-runner:
         inputs:
         - gradle_task: assembleDebug
@@ -58,17 +58,17 @@ workflows:
     - path::./:
         title: Execute step without NDK version
         inputs:
-        - ndk_revision: ""
+        - ndk_version: ""
     - path::./:
         title: Execute step with NDK r18
         inputs:
-        - ndk_revision: 18
+        - ndk_version: 18.1.5063045
     - script:
         title: Check installed NDK version
         inputs:
         - content: |-
-            EXPECTED_VERSION=18.0.5002713
-            NDK_VERSION=`cat $ANDROID_HOME/ndk-bundle/source.properties | grep Pkg.Revision | cut -d'=' -f2 | cut -d' ' -f2`
+            EXPECTED_VERSION=18.1.5063045
+            NDK_VERSION=`cat $ANDROID_HOME/ndk/18.1.5063045/source.properties | grep Pkg.Revision | cut -d'=' -f2 | cut -d' ' -f2`
             if [ $NDK_VERSION != $EXPECTED_VERSION ]; then
               echo "Unexpected installed NDK version: $NDK_VERSION"
               echo "Expected: $EXPECTED_VERSION"
@@ -79,13 +79,13 @@ workflows:
     - path::./:
         title: Execute step again with NDK r18
         inputs:
-        - ndk_revision: 18
+        - ndk_version: 18.1.5063045
     - script:
         title: Check installed NDK version
         inputs:
         - content: |-
-            EXPECTED_VERSION=18.0.5002713
-            NDK_VERSION=`cat $ANDROID_HOME/ndk-bundle/source.properties | grep Pkg.Revision | cut -d'=' -f2 | cut -d' ' -f2`
+            EXPECTED_VERSION=18.1.5063045
+            NDK_VERSION=`cat $ANDROID_HOME/ndk/18.1.5063045/source.properties | grep Pkg.Revision | cut -d'=' -f2 | cut -d' ' -f2`
             if [ $NDK_VERSION != $EXPECTED_VERSION ]; then
               echo "Unexpected installed NDK version: $NDK_VERSION"
               echo "Expected: $EXPECTED_VERSION"
@@ -96,13 +96,13 @@ workflows:
     - path::./:
         title: Execute step with NDK r17
         inputs:
-        - ndk_revision: 17
+        - ndk_version: 17.2.4988734
     - script:
         title: Check installed NDK version
         inputs:
         - content: |-
-            EXPECTED_VERSION=17.0.4754217
-            NDK_VERSION=`cat $ANDROID_HOME/ndk-bundle/source.properties | grep Pkg.Revision | cut -d'=' -f2 | cut -d' ' -f2`
+            EXPECTED_VERSION=17.2.4988734
+            NDK_VERSION=`cat $ANDROID_HOME/ndk/17.2.4988734/source.properties | grep Pkg.Revision | cut -d'=' -f2 | cut -d' ' -f2`
             if [ $NDK_VERSION != $EXPECTED_VERSION ]; then
               echo "Unexpected installed NDK version: $NDK_VERSION"
               echo "Expected: $EXPECTED_VERSION"
@@ -114,13 +114,13 @@ workflows:
         title: Execute step with NDK r22
         description: NDK r22 doesn't contain the platforms dir anymore
         inputs:
-        - ndk_revision: 22
+        - ndk_version: 22.1.7171670
     - script:
         title: Check installed NDK version
         inputs:
         - content: |-
-            EXPECTED_VERSION=22.0.7026061
-            NDK_VERSION=`cat $ANDROID_HOME/ndk-bundle/source.properties | grep Pkg.Revision | cut -d'=' -f2 | cut -d' ' -f2`
+            EXPECTED_VERSION=22.1.7171670
+            NDK_VERSION=`cat $ANDROID_HOME/ndk/22.1.7171670/source.properties | grep Pkg.Revision | cut -d'=' -f2 | cut -d' ' -f2`
             if [ $NDK_VERSION != $EXPECTED_VERSION ]; then
               echo "Unexpected installed NDK version: $NDK_VERSION"
               echo "Expected: $EXPECTED_VERSION"

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/bitrise-steplib/steps-install-missing-android-tools
 go 1.16
 
 require (
-	github.com/bitrise-io/go-android v0.0.0-20210913110142-e16d773393da
+	github.com/bitrise-io/go-android v0.0.0-20210913151943-e1ea0b4df36d
 	github.com/bitrise-io/go-steputils v0.0.0-20210831050118-9a8de76b2f19
 	github.com/bitrise-io/go-utils v0.0.0-20210903141333-9e20aaef213f
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,10 @@ github.com/bitrise-io/go-android v0.0.0-20210823111323-ed4093b7c810 h1:dUAhhLAbl
 github.com/bitrise-io/go-android v0.0.0-20210823111323-ed4093b7c810/go.mod h1:yTe4i6RfahvAmOChFrS9uCPmJiH0eBEV4jya30v2tTc=
 github.com/bitrise-io/go-android v0.0.0-20210913110142-e16d773393da h1:KGMY7kecTBjRMZ52s+8JfNkhLnRPbFMyFiWLEUWIJkk=
 github.com/bitrise-io/go-android v0.0.0-20210913110142-e16d773393da/go.mod h1:yTe4i6RfahvAmOChFrS9uCPmJiH0eBEV4jya30v2tTc=
+github.com/bitrise-io/go-android v0.0.0-20210913142655-1ae0ebd3ce4b h1:zRNhn+C6vJSUn6gR8AUT3kIZMJshJuum7jwh2P0k2cU=
+github.com/bitrise-io/go-android v0.0.0-20210913142655-1ae0ebd3ce4b/go.mod h1:yTe4i6RfahvAmOChFrS9uCPmJiH0eBEV4jya30v2tTc=
+github.com/bitrise-io/go-android v0.0.0-20210913151943-e1ea0b4df36d h1:F4VCaMk4hZZSwI5MiyBwVnkxmgmvkOz4+uXAacEaRC0=
+github.com/bitrise-io/go-android v0.0.0-20210913151943-e1ea0b4df36d/go.mod h1:yTe4i6RfahvAmOChFrS9uCPmJiH0eBEV4jya30v2tTc=
 github.com/bitrise-io/go-steputils v0.0.0-20210514150206-5b6261447e77/go.mod h1:H0iZjgsAR5NA6pnlD/zKB6AbxEsskq55pwJ9klVmP8w=
 github.com/bitrise-io/go-steputils v0.0.0-20210527075147-910ce7a105a1 h1:gi29hTdxGXAGQvZckPZ9V8BAEfP3eK/tiZgTC5s6h1c=
 github.com/bitrise-io/go-steputils v0.0.0-20210527075147-910ce7a105a1/go.mod h1:H0iZjgsAR5NA6pnlD/zKB6AbxEsskq55pwJ9klVmP8w=

--- a/step.yml
+++ b/step.yml
@@ -57,8 +57,8 @@ inputs:
         **The path should be relative** to the repository root, for example: `./gradlew`,
         or if it's in a sub directory: `./sub/dir/gradlew`.
       is_required: true
-  - ndk_revision:
+  - ndk_version:
     opts:
-      title: NDK Revision
-      summary: "The step will install the given revision of the Android NDK.(eg.: 18) Leave this input empty if you are not using NDK in your project."
-      description: "The step will install the given revision of the Android NDK.(eg.: 18) Leave this input empty if you are not using NDK in your project."
+      title: NDK version
+      summary: "NDK version to install. Leave this input empty if you are not using the Native Development Kit in your project."
+      description: "NDK version to install, for example `23.0.7599858`. Run `sdkmanager --list` on your machine to see all available versions. Leave this input empty if you are not using the Native Development Kit in your project."

--- a/vendor/github.com/bitrise-io/go-android/sdkcomponent/sdkcomponent.go
+++ b/vendor/github.com/bitrise-io/go-android/sdkcomponent/sdkcomponent.go
@@ -182,11 +182,11 @@ type Extras struct {
 // GooglePlayServicesInstallComponents ...
 func GooglePlayServicesInstallComponents() []Extras {
 	return []Extras{
-		Extras{
+		{
 			Provider:    "google",
 			PackageName: "m2repository",
 		},
-		Extras{
+		{
 			Provider:    "google",
 			PackageName: "google_play_services",
 		},
@@ -196,11 +196,11 @@ func GooglePlayServicesInstallComponents() []Extras {
 // LegacyGooglePlayServicesInstallComponents ...
 func LegacyGooglePlayServicesInstallComponents() []Extras {
 	return []Extras{
-		Extras{
+		{
 			Provider:    "google",
 			PackageName: "m2repository",
 		},
-		Extras{
+		{
 			Provider:    "google",
 			PackageName: "google_play_services",
 		},
@@ -210,21 +210,17 @@ func LegacyGooglePlayServicesInstallComponents() []Extras {
 // SupportLibraryInstallComponents ...
 func SupportLibraryInstallComponents() []Extras {
 	return []Extras{
-		Extras{
+		{
 			Provider:    "android",
 			PackageName: "m2repository",
 		},
-		// Extras{
-		// 	Provider:    "android",
-		// 	PackageName: "support",
-		// },
 	}
 }
 
 // LegacySupportLibraryInstallComponents ...
 func LegacySupportLibraryInstallComponents() []Extras {
 	return []Extras{
-		Extras{
+		{
 			Provider:    "android",
 			PackageName: "m2repository",
 		},
@@ -257,4 +253,30 @@ func (component Extras) InstallPathInAndroidHome() string {
 // InstallationIndicatorFile ...
 func (component Extras) InstallationIndicatorFile() string {
 	return ""
+}
+
+// NDK ...
+type NDK struct {
+	Version string
+}
+
+// GetSDKStylePath ...
+func (component NDK) GetSDKStylePath() string {
+	return fmt.Sprintf("ndk;%s", component.Version)
+}
+
+// GetLegacySDKStylePath ...
+func (component NDK) GetLegacySDKStylePath() string {
+	// Not relevant anymore
+	return ""
+}
+
+// InstallPathInAndroidHome ...
+func (component NDK) InstallPathInAndroidHome() string {
+	return filepath.Join("ndk", component.Version)
+}
+
+// InstallationIndicatorFile ...
+func (component NDK) InstallationIndicatorFile() string {
+	return "source.properties"
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/bitrise-io/go-android v0.0.0-20210913110142-e16d773393da
+# github.com/bitrise-io/go-android v0.0.0-20210913151943-e1ea0b4df36d
 ## explicit
 github.com/bitrise-io/go-android/sdk
 github.com/bitrise-io/go-android/sdkcomponent


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [X] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [X] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR* [version update](https://semver.org/)

### Context
NDK r23 is no longer installable with this step, because its download URL differs from previous versions.

### Changes

- Change NDK installation to use the `sdkmanager --install` command directly (instead of download URLs)
- Change `ndk_revision` input to `ndk_version` because `sdkmanager` requires the full version string, not just the revision
- This change also means that NDK will be installed to `$SDK/ndk/$VERSION` instead of `$SDK/ndk-bundle`, but we also set `$ANDROID_NDK_HOME` to this location to make it compatible with [older Gradle projects](https://github.com/android/ndk-samples/wiki/Configure-NDK-Path)
- Fix a latent bug in `androidcomponents.go` 😉 
- Add generated README

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
