### PR TITLE
Add context to error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@ Install Android SDK components that are required for the app.
 <summary>Description</summary>
 
 
-This Step makes sure that the required Android SDK components (platforms and build-tools) are installed. To do so, the Step runs the `gradlew dependencies` command. 
+This Step makes sure that required Android SDK components (platforms and build-tools) are installed. To do so, the Step runs the `gradlew dependencies` command.
 
-If the Android Plugin for Gradle version is 2.2.0 or higher, the plugin will automatically download and install the missing components during the Gradle command.  
-Otherwise the command will fail and the Step parses the command's output to determine which SDK components are missing and installs them.
+If the Android Plugin for Gradle version is 2.2.0 or higher, the plugin will download and install the missing components during the Gradle command.
+Otherwise the command fails and the Step parses the command's output to determine which SDK components are missing and installs them.
 
 ### Configuring the Step
 
 1. Set the path of the `gradlew` file.
 
-   The default value is of the $PROJECT_LOCATION Environment Variable.
+   The default value is that of the $PROJECT_LOCATION Environment Variable.
 
 1. If you use an Android NDK in your app, set its revision in the **NDK Revision** input.
 
@@ -35,11 +35,11 @@ If the Step fails, check that your repo actually contains a `gradlew` file. With
 * [Install React Native](https://www.bitrise.io/integrations/steps/install-react-native)
 </details>
 
-## 🧩To Get started
+## 🧩 Get started
 
 Add this step directly to your workflow in the [Bitrise Workflow Editor](https://devcenter.bitrise.io/steps-and-workflows/steps-and-workflows-index/).
 
-You could also run this step directly with [Bitrise CLI](https://github.com/bitrise-io/bitrise).
+You can also run this step directly with [Bitrise CLI](https://github.com/bitrise-io/bitrise).
 
 ## ⚙️ Configuration
 

--- a/main.go
+++ b/main.go
@@ -127,7 +127,7 @@ func main() {
 	// Input validation
 	var config Config
 	if err := stepconf.Parse(&config); err != nil {
-		log.Errorf("process config: %s", err)
+		failf("process config: %s", err)
 	}
 
 	fmt.Println()

--- a/main.go
+++ b/main.go
@@ -127,7 +127,7 @@ func main() {
 	// Input validation
 	var config Config
 	if err := stepconf.Parse(&config); err != nil {
-		log.Errorf("%s", err)
+		log.Errorf("process config: %s", err)
 	}
 
 	fmt.Println()
@@ -139,7 +139,7 @@ func main() {
 	// Set executable permission for gradlew
 	log.Printf("Set executable permission for gradlew")
 	if err := os.Chmod(config.GradlewPath, 0770); err != nil {
-		failf("Failed to set executable permission for gradlew, error: %s", err)
+		failf("run: failed to set executable permission for gradlew, error: %s", err)
 	}
 
 	// Initialize Android SDK
@@ -150,7 +150,7 @@ func main() {
 		AndroidSDKRoot: config.AndroidSDKRoot,
 	})
 	if err != nil {
-		failf("Failed to initialize Android SDK: %s", err)
+		failf("run: failed to initialize Android SDK: %s", err)
 	}
 
 	fmt.Println()
@@ -159,22 +159,22 @@ func main() {
 
 		_, err := version.NewVersion(config.NDKVersion)
 		if err != nil {
-			failf(fmt.Sprintf("'%s' is not a valid NDK version. This should be the full version number, such as 23.0.7599858. To see all available versions, run 'sdkmanager --list'", config.NDKVersion))
+			failf(fmt.Sprintf("install dependencies: '%s' is not a valid NDK version. This should be the full version number, such as 23.0.7599858. To see all available versions, run 'sdkmanager --list'", config.NDKVersion))
 		}
 
 		if err := updateNDK(config.NDKVersion, androidSdk); err != nil {
-			failf("Failed to install new NDK package, error: %s", err)
+			failf("install dependencies: failed to install new NDK package, error: %s", err)
 		}
 	} else {
 		log.Infof("Clearing NDK environment")
 		log.Printf("Unset ANDROID_NDK_HOME")
 
 		if err := os.Unsetenv("ANDROID_NDK_HOME"); err != nil {
-			failf("Failed to unset environment variable, error: %s", err)
+			failf("install dependencies: failed to unset environment variable, error: %s", err)
 		}
 
 		if err := tools.ExportEnvironmentWithEnvman("ANDROID_NDK_HOME", ""); err != nil {
-			failf("Failed to set environment variable, error: %s", err)
+			failf("install dependencies: failed to set environment variable, error: %s", err)
 		}
 	}
 
@@ -182,7 +182,7 @@ func main() {
 	log.Printf("Ensure android licences")
 
 	if err := androidcomponents.InstallLicences(androidSdk); err != nil {
-		failf("Failed to ensure android licences, error: %s", err)
+		failf("install dependencies: failed to ensure android licences, error: %s", err)
 	}
 
 	// Ensure required Android SDK components
@@ -190,7 +190,7 @@ func main() {
 	log.Infof("Ensure required Android SDK components")
 
 	if err := androidcomponents.Ensure(androidSdk, config.GradlewPath); err != nil {
-		failf("Failed to ensure android components, error: %s", err)
+		failf("install dependencies: failed to ensure android components, error: %s", err)
 	}
 
 	fmt.Println()

--- a/main.go
+++ b/main.go
@@ -127,7 +127,7 @@ func main() {
 	// Input validation
 	var config Config
 	if err := stepconf.Parse(&config); err != nil {
-		failf("process config: %s", err)
+		failf("Process config: %s", err)
 	}
 
 	fmt.Println()
@@ -139,7 +139,7 @@ func main() {
 	// Set executable permission for gradlew
 	log.Printf("Set executable permission for gradlew")
 	if err := os.Chmod(config.GradlewPath, 0770); err != nil {
-		failf("run: failed to set executable permission for gradlew, error: %s", err)
+		failf("Run: failed to set executable permission for gradlew, error: %s", err)
 	}
 
 	// Initialize Android SDK
@@ -150,7 +150,7 @@ func main() {
 		AndroidSDKRoot: config.AndroidSDKRoot,
 	})
 	if err != nil {
-		failf("run: failed to initialize Android SDK: %s", err)
+		failf("Run: failed to initialize Android SDK: %s", err)
 	}
 
 	fmt.Println()
@@ -159,22 +159,22 @@ func main() {
 
 		_, err := version.NewVersion(config.NDKVersion)
 		if err != nil {
-			failf(fmt.Sprintf("run: '%s' is not a valid NDK version. This should be the full version number, such as 23.0.7599858. To see all available versions, run 'sdkmanager --list'", config.NDKVersion))
+			failf(fmt.Sprintf("Run: '%s' is not a valid NDK version. This should be the full version number, such as 23.0.7599858. To see all available versions, run 'sdkmanager --list'", config.NDKVersion))
 		}
 
 		if err := updateNDK(config.NDKVersion, androidSdk); err != nil {
-			failf("run: failed to install new NDK package, error: %s", err)
+			failf("Run: failed to install new NDK package, error: %s", err)
 		}
 	} else {
 		log.Infof("Clearing NDK environment")
 		log.Printf("Unset ANDROID_NDK_HOME")
 
 		if err := os.Unsetenv("ANDROID_NDK_HOME"); err != nil {
-			failf("run: failed to unset environment variable, error: %s", err)
+			failf("Run: failed to unset environment variable, error: %s", err)
 		}
 
 		if err := tools.ExportEnvironmentWithEnvman("ANDROID_NDK_HOME", ""); err != nil {
-			failf("run: failed to set environment variable, error: %s", err)
+			failf("Run: failed to set environment variable, error: %s", err)
 		}
 	}
 
@@ -182,7 +182,7 @@ func main() {
 	log.Printf("Ensure android licences")
 
 	if err := androidcomponents.InstallLicences(androidSdk); err != nil {
-		failf("run: failed to ensure android licences, error: %s", err)
+		failf("Run: failed to ensure android licences, error: %s", err)
 	}
 
 	// Ensure required Android SDK components
@@ -190,7 +190,7 @@ func main() {
 	log.Infof("Ensure required Android SDK components")
 
 	if err := androidcomponents.Ensure(androidSdk, config.GradlewPath); err != nil {
-		failf("run: failed to ensure android components, error: %s", err)
+		failf("Run: failed to ensure android components, error: %s", err)
 	}
 
 	fmt.Println()

--- a/main.go
+++ b/main.go
@@ -159,22 +159,22 @@ func main() {
 
 		_, err := version.NewVersion(config.NDKVersion)
 		if err != nil {
-			failf(fmt.Sprintf("install dependencies: '%s' is not a valid NDK version. This should be the full version number, such as 23.0.7599858. To see all available versions, run 'sdkmanager --list'", config.NDKVersion))
+			failf(fmt.Sprintf("run: '%s' is not a valid NDK version. This should be the full version number, such as 23.0.7599858. To see all available versions, run 'sdkmanager --list'", config.NDKVersion))
 		}
 
 		if err := updateNDK(config.NDKVersion, androidSdk); err != nil {
-			failf("install dependencies: failed to install new NDK package, error: %s", err)
+			failf("run: failed to install new NDK package, error: %s", err)
 		}
 	} else {
 		log.Infof("Clearing NDK environment")
 		log.Printf("Unset ANDROID_NDK_HOME")
 
 		if err := os.Unsetenv("ANDROID_NDK_HOME"); err != nil {
-			failf("install dependencies: failed to unset environment variable, error: %s", err)
+			failf("run: failed to unset environment variable, error: %s", err)
 		}
 
 		if err := tools.ExportEnvironmentWithEnvman("ANDROID_NDK_HOME", ""); err != nil {
-			failf("install dependencies: failed to set environment variable, error: %s", err)
+			failf("run: failed to set environment variable, error: %s", err)
 		}
 	}
 
@@ -182,7 +182,7 @@ func main() {
 	log.Printf("Ensure android licences")
 
 	if err := androidcomponents.InstallLicences(androidSdk); err != nil {
-		failf("install dependencies: failed to ensure android licences, error: %s", err)
+		failf("run: failed to ensure android licences, error: %s", err)
 	}
 
 	// Ensure required Android SDK components
@@ -190,7 +190,7 @@ func main() {
 	log.Infof("Ensure required Android SDK components")
 
 	if err := androidcomponents.Ensure(androidSdk, config.GradlewPath); err != nil {
-		failf("install dependencies: failed to ensure android components, error: %s", err)
+		failf("run: failed to ensure android components, error: %s", err)
 	}
 
 	fmt.Println()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [X] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [X] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

Adding more context to error messages printed to the build log. 

### Changes

- Add prefix to error messages in calls to `failf()`
- Regenerate README

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
