### PR TITLE
Add step input for specifying additional gradle options

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ You can also run this step directly with [Bitrise CLI](https://github.com/bitris
 | --- | --- | --- | --- |
 | `gradlew_path` | Using a Gradle Wrapper (gradlew) is required, as the wrapper is what makes sure that the right Gradle version is installed and used for the build. __You can find more information about the Gradle Wrapper (gradlew), and about how you can generate one (if you would not have one already)__ in the official guide at: [https://docs.gradle.org/current/userguide/gradle_wrapper.html](https://docs.gradle.org/current/userguide/gradle_wrapper.html).  **The path should be relative** to the repository root, for example: `./gradlew`, or if it's in a sub directory: `./sub/dir/gradlew`.  | required | `$GRADLEW_PATH` |
 | `ndk_version` | NDK version to install, for example `23.0.7599858`. Run `sdkmanager --list` on your machine to see all available versions. Leave this input empty if you are not using the Native Development Kit in your project. |  |  |
+| `gradlew_dependencies_options` | Additional options to be added to the executed gradlew tasks command.  The step runs `gradlew dependencies --stacktrace` to list the missing dependencies and to install them. Additional options will be appended to the end of this command.  Example: `--configuration-cache-problems=warn`. |  |  |
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ You can also run this step directly with [Bitrise CLI](https://github.com/bitris
 | --- | --- | --- | --- |
 | `gradlew_path` | Using a Gradle Wrapper (gradlew) is required, as the wrapper is what makes sure that the right Gradle version is installed and used for the build. __You can find more information about the Gradle Wrapper (gradlew), and about how you can generate one (if you would not have one already)__ in the official guide at: [https://docs.gradle.org/current/userguide/gradle_wrapper.html](https://docs.gradle.org/current/userguide/gradle_wrapper.html).  **The path should be relative** to the repository root, for example: `./gradlew`, or if it's in a sub directory: `./sub/dir/gradlew`.  | required | `$GRADLEW_PATH` |
 | `ndk_version` | NDK version to install, for example `23.0.7599858`. Run `sdkmanager --list` on your machine to see all available versions. Leave this input empty if you are not using the Native Development Kit in your project. |  |  |
-| `gradlew_dependencies_options` | Additional options to be added to the executed gradlew tasks command.  The step runs `gradlew dependencies --stacktrace` to list the missing dependencies and to install them. Additional options will be appended to the end of this command.  Example: `--configuration-cache-problems=warn`. |  |  |
+| `gradlew_dependencies_options` | Additional options to be added to the executed `gradlew dependencies` command.  The step runs `gradlew dependencies --stacktrace` to list and install the missing project dependencies.  Additional options will be appended to the end of this command.  Example: `--configuration-cache-problems=warn`. |  |  |
 </details>
 
 <details>

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -40,6 +40,8 @@ workflows:
         - branch: master
     - path::./:
         title: Execute step
+        inputs:
+        - gradlew_dependencies_options: --configuration-cache-problems=warn
     - gradle-runner:
         inputs:
         - gradle_task: assembleDebug

--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,5 @@ require (
 	github.com/bitrise-io/go-steputils v1.0.1
 	github.com/bitrise-io/go-utils v1.0.1
 	github.com/hashicorp/go-version v1.3.0
+	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 )

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/hashicorp/go-retryablehttp v0.7.0 h1:eu1EI/mbirUgP5C8hVsTNaGZreBDlYiw
 github.com/hashicorp/go-retryablehttp v0.7.0/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/go-version v1.3.0 h1:McDWVJIU/y+u1BRV06dPaLfLCaT7fUTJLp5r04x7iNw=
 github.com/hashicorp/go-version v1.3.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
+github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=

--- a/main.go
+++ b/main.go
@@ -15,16 +15,18 @@ import (
 	"github.com/bitrise-io/go-utils/log"
 	"github.com/bitrise-steplib/steps-install-missing-android-tools/androidcomponents"
 	"github.com/hashicorp/go-version"
+	"github.com/kballard/go-shellquote"
 )
 
 const androidNDKHome = "ANDROID_NDK_HOME"
 
 // Config ...
 type Config struct {
-	GradlewPath    string `env:"gradlew_path,file"`
-	AndroidHome    string `env:"ANDROID_HOME"`
-	AndroidSDKRoot string `env:"ANDROID_SDK_ROOT"`
-	NDKVersion     string `env:"ndk_version"`
+	GradlewPath                string `env:"gradlew_path,file"`
+	AndroidHome                string `env:"ANDROID_HOME"`
+	AndroidSDKRoot             string `env:"ANDROID_SDK_ROOT"`
+	NDKVersion                 string `env:"ndk_version"`
+	GradlewDependenciesOptions string `env:"gradlew_dependencies_options"`
 }
 
 func failf(format string, v ...interface{}) {
@@ -129,6 +131,10 @@ func main() {
 	if err := stepconf.Parse(&config); err != nil {
 		failf("Process config: %s", err)
 	}
+	gradlewDependenciesOptions, err := shellquote.Split(config.GradlewDependenciesOptions)
+	if err != nil {
+		failf("provided gradlew_dependencies_options (%s) are not valid CLI parameters: %s", config.GradlewDependenciesOptions, err)
+	}
 
 	fmt.Println()
 	stepconf.Print(config)
@@ -189,7 +195,7 @@ func main() {
 	fmt.Println()
 	log.Infof("Ensure required Android SDK components")
 
-	if err := androidcomponents.Ensure(androidSdk, config.GradlewPath); err != nil {
+	if err := androidcomponents.Ensure(androidSdk, config.GradlewPath, gradlewDependenciesOptions); err != nil {
 		failf("Run: failed to ensure android components, error: %s", err)
 	}
 

--- a/step.yml
+++ b/step.yml
@@ -73,4 +73,3 @@ inputs:
       Additional options will be appended to the end of this command.
 
       Example: `--configuration-cache-problems=warn`.
-

--- a/step.yml
+++ b/step.yml
@@ -64,12 +64,13 @@ inputs:
     description: NDK version to install, for example `23.0.7599858`. Run `sdkmanager --list` on your machine to see all available versions. Leave this input empty if you are not using the Native Development Kit in your project.
 - gradlew_dependencies_options:
   opts:
-    title: Additional options for the gradlew tasks command
-    summary: Additional options to be added to the executed gradlew tasks command.
+    title: Additional options for the `gradlew dependencies` command
+    summary: Additional options to be added to the executed `gradlew dependencies` command.
     description: |-
-      Additional options to be added to the executed gradlew tasks command.
+      Additional options to be added to the executed `gradlew dependencies` command.
 
-      The step runs `gradlew dependencies --stacktrace` to list the missing dependencies and to install them.
+      The step runs `gradlew dependencies --stacktrace` to list and install the missing project dependencies.
+
       Additional options will be appended to the end of this command.
 
       Example: `--configuration-cache-problems=warn`.

--- a/step.yml
+++ b/step.yml
@@ -62,3 +62,15 @@ inputs:
     title: NDK version
     summary: NDK version to install. Leave this input empty if you are not using the Native Development Kit in your project.
     description: NDK version to install, for example `23.0.7599858`. Run `sdkmanager --list` on your machine to see all available versions. Leave this input empty if you are not using the Native Development Kit in your project.
+- gradlew_dependencies_options:
+  opts:
+    title: Additional options for the gradlew tasks command
+    summary: Additional options to be added to the executed gradlew tasks command.
+    description: |-
+      Additional options to be added to the executed gradlew tasks command.
+
+      The step runs `gradlew dependencies --stacktrace` to list the missing dependencies and to install them.
+      Additional options will be appended to the end of this command.
+
+      Example: `--configuration-cache-problems=warn`.
+

--- a/vendor/github.com/kballard/go-shellquote/LICENSE
+++ b/vendor/github.com/kballard/go-shellquote/LICENSE
@@ -1,0 +1,19 @@
+Copyright (C) 2014 Kevin Ballard
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/kballard/go-shellquote/README
+++ b/vendor/github.com/kballard/go-shellquote/README
@@ -1,0 +1,36 @@
+PACKAGE
+
+package shellquote
+    import "github.com/kballard/go-shellquote"
+
+    Shellquote provides utilities for joining/splitting strings using sh's
+    word-splitting rules.
+
+VARIABLES
+
+var (
+    UnterminatedSingleQuoteError = errors.New("Unterminated single-quoted string")
+    UnterminatedDoubleQuoteError = errors.New("Unterminated double-quoted string")
+    UnterminatedEscapeError      = errors.New("Unterminated backslash-escape")
+)
+
+
+FUNCTIONS
+
+func Join(args ...string) string
+    Join quotes each argument and joins them with a space. If passed to
+    /bin/sh, the resulting string will be split back into the original
+    arguments.
+
+func Split(input string) (words []string, err error)
+    Split splits a string according to /bin/sh's word-splitting rules. It
+    supports backslash-escapes, single-quotes, and double-quotes. Notably it
+    does not support the $'' style of quoting. It also doesn't attempt to
+    perform any other sort of expansion, including brace expansion, shell
+    expansion, or pathname expansion.
+
+    If the given input has an unterminated quoted string or ends in a
+    backslash-escape, one of UnterminatedSingleQuoteError,
+    UnterminatedDoubleQuoteError, or UnterminatedEscapeError is returned.
+
+

--- a/vendor/github.com/kballard/go-shellquote/doc.go
+++ b/vendor/github.com/kballard/go-shellquote/doc.go
@@ -1,0 +1,3 @@
+// Shellquote provides utilities for joining/splitting strings using sh's
+// word-splitting rules.
+package shellquote

--- a/vendor/github.com/kballard/go-shellquote/quote.go
+++ b/vendor/github.com/kballard/go-shellquote/quote.go
@@ -1,0 +1,102 @@
+package shellquote
+
+import (
+	"bytes"
+	"strings"
+	"unicode/utf8"
+)
+
+// Join quotes each argument and joins them with a space.
+// If passed to /bin/sh, the resulting string will be split back into the
+// original arguments.
+func Join(args ...string) string {
+	var buf bytes.Buffer
+	for i, arg := range args {
+		if i != 0 {
+			buf.WriteByte(' ')
+		}
+		quote(arg, &buf)
+	}
+	return buf.String()
+}
+
+const (
+	specialChars      = "\\'\"`${[|&;<>()*?!"
+	extraSpecialChars = " \t\n"
+	prefixChars       = "~"
+)
+
+func quote(word string, buf *bytes.Buffer) {
+	// We want to try to produce a "nice" output. As such, we will
+	// backslash-escape most characters, but if we encounter a space, or if we
+	// encounter an extra-special char (which doesn't work with
+	// backslash-escaping) we switch over to quoting the whole word. We do this
+	// with a space because it's typically easier for people to read multi-word
+	// arguments when quoted with a space rather than with ugly backslashes
+	// everywhere.
+	origLen := buf.Len()
+
+	if len(word) == 0 {
+		// oops, no content
+		buf.WriteString("''")
+		return
+	}
+
+	cur, prev := word, word
+	atStart := true
+	for len(cur) > 0 {
+		c, l := utf8.DecodeRuneInString(cur)
+		cur = cur[l:]
+		if strings.ContainsRune(specialChars, c) || (atStart && strings.ContainsRune(prefixChars, c)) {
+			// copy the non-special chars up to this point
+			if len(cur) < len(prev) {
+				buf.WriteString(prev[0 : len(prev)-len(cur)-l])
+			}
+			buf.WriteByte('\\')
+			buf.WriteRune(c)
+			prev = cur
+		} else if strings.ContainsRune(extraSpecialChars, c) {
+			// start over in quote mode
+			buf.Truncate(origLen)
+			goto quote
+		}
+		atStart = false
+	}
+	if len(prev) > 0 {
+		buf.WriteString(prev)
+	}
+	return
+
+quote:
+	// quote mode
+	// Use single-quotes, but if we find a single-quote in the word, we need
+	// to terminate the string, emit an escaped quote, and start the string up
+	// again
+	inQuote := false
+	for len(word) > 0 {
+		i := strings.IndexRune(word, '\'')
+		if i == -1 {
+			break
+		}
+		if i > 0 {
+			if !inQuote {
+				buf.WriteByte('\'')
+				inQuote = true
+			}
+			buf.WriteString(word[0:i])
+		}
+		word = word[i+1:]
+		if inQuote {
+			buf.WriteByte('\'')
+			inQuote = false
+		}
+		buf.WriteString("\\'")
+	}
+	if len(word) > 0 {
+		if !inQuote {
+			buf.WriteByte('\'')
+		}
+		buf.WriteString(word)
+		buf.WriteByte('\'')
+	}
+}

--- a/vendor/github.com/kballard/go-shellquote/unquote.go
+++ b/vendor/github.com/kballard/go-shellquote/unquote.go
@@ -1,0 +1,156 @@
+package shellquote
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"unicode/utf8"
+)
+
+var (
+	UnterminatedSingleQuoteError = errors.New("Unterminated single-quoted string")
+	UnterminatedDoubleQuoteError = errors.New("Unterminated double-quoted string")
+	UnterminatedEscapeError      = errors.New("Unterminated backslash-escape")
+)
+
+var (
+	splitChars        = " \n\t"
+	singleChar        = '\''
+	doubleChar        = '"'
+	escapeChar        = '\\'
+	doubleEscapeChars = "$`\"\n\\"
+)
+
+// Split splits a string according to /bin/sh's word-splitting rules. It
+// supports backslash-escapes, single-quotes, and double-quotes. Notably it does
+// not support the $'' style of quoting. It also doesn't attempt to perform any
+// other sort of expansion, including brace expansion, shell expansion, or
+// pathname expansion.
+//
+// If the given input has an unterminated quoted string or ends in a
+// backslash-escape, one of UnterminatedSingleQuoteError,
+// UnterminatedDoubleQuoteError, or UnterminatedEscapeError is returned.
+func Split(input string) (words []string, err error) {
+	var buf bytes.Buffer
+	words = make([]string, 0)
+
+	for len(input) > 0 {
+		// skip any splitChars at the start
+		c, l := utf8.DecodeRuneInString(input)
+		if strings.ContainsRune(splitChars, c) {
+			input = input[l:]
+			continue
+		} else if c == escapeChar {
+			// Look ahead for escaped newline so we can skip over it
+			next := input[l:]
+			if len(next) == 0 {
+				err = UnterminatedEscapeError
+				return
+			}
+			c2, l2 := utf8.DecodeRuneInString(next)
+			if c2 == '\n' {
+				input = next[l2:]
+				continue
+			}
+		}
+
+		var word string
+		word, input, err = splitWord(input, &buf)
+		if err != nil {
+			return
+		}
+		words = append(words, word)
+	}
+	return
+}
+
+func splitWord(input string, buf *bytes.Buffer) (word string, remainder string, err error) {
+	buf.Reset()
+
+raw:
+	{
+		cur := input
+		for len(cur) > 0 {
+			c, l := utf8.DecodeRuneInString(cur)
+			cur = cur[l:]
+			if c == singleChar {
+				buf.WriteString(input[0 : len(input)-len(cur)-l])
+				input = cur
+				goto single
+			} else if c == doubleChar {
+				buf.WriteString(input[0 : len(input)-len(cur)-l])
+				input = cur
+				goto double
+			} else if c == escapeChar {
+				buf.WriteString(input[0 : len(input)-len(cur)-l])
+				input = cur
+				goto escape
+			} else if strings.ContainsRune(splitChars, c) {
+				buf.WriteString(input[0 : len(input)-len(cur)-l])
+				return buf.String(), cur, nil
+			}
+		}
+		if len(input) > 0 {
+			buf.WriteString(input)
+			input = ""
+		}
+		goto done
+	}
+
+escape:
+	{
+		if len(input) == 0 {
+			return "", "", UnterminatedEscapeError
+		}
+		c, l := utf8.DecodeRuneInString(input)
+		if c == '\n' {
+			// a backslash-escaped newline is elided from the output entirely
+		} else {
+			buf.WriteString(input[:l])
+		}
+		input = input[l:]
+	}
+	goto raw
+
+single:
+	{
+		i := strings.IndexRune(input, singleChar)
+		if i == -1 {
+			return "", "", UnterminatedSingleQuoteError
+		}
+		buf.WriteString(input[0:i])
+		input = input[i+1:]
+		goto raw
+	}
+
+double:
+	{
+		cur := input
+		for len(cur) > 0 {
+			c, l := utf8.DecodeRuneInString(cur)
+			cur = cur[l:]
+			if c == doubleChar {
+				buf.WriteString(input[0 : len(input)-len(cur)-l])
+				input = cur
+				goto raw
+			} else if c == escapeChar {
+				// bash only supports certain escapes in double-quoted strings
+				c2, l2 := utf8.DecodeRuneInString(cur)
+				cur = cur[l2:]
+				if strings.ContainsRune(doubleEscapeChars, c2) {
+					buf.WriteString(input[0 : len(input)-len(cur)-l-l2])
+					if c2 == '\n' {
+						// newline is special, skip the backslash entirely
+					} else {
+						buf.WriteRune(c2)
+					}
+					input = cur
+				}
+			}
+		}
+		return "", "", UnterminatedDoubleQuoteError
+	}
+
+done:
+	return buf.String(), input, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -25,3 +25,6 @@ github.com/hashicorp/go-retryablehttp
 # github.com/hashicorp/go-version v1.3.0
 ## explicit
 github.com/hashicorp/go-version
+# github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
+## explicit
+github.com/kballard/go-shellquote


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version

Requires a *MINOR* [version update](https://semver.org/)

### Context

The Step is running `gradlew dependencies` command in order to list the given project's missing dependencies.

To make the Step more felxibale and align our Step development guideline ([Provide input for additional command-line arguments](https://github.com/bitrise-io/bitrise/blob/master/_docs/step-development-guideline.md#provide-input-for-additional-command-line-arguments)) this PR introduces a new Step input for specifying additional options for the `gradlew dependencies` command.

With this change, users can overcome, for example, issues with the incubating Configuration cache feature while migrating the project by passing the `--no-configuration-cache` or `--configuration-cache-problems=warn` options.

### Changes

- New Step Input (`gradlew_dependencies_options`) was introduced for passing additional options to the `gradlew dependencies` command.

### Investigation details

Gradle Configuration cache: https://docs.gradle.org/7.4.2/userguide/configuration_cache.html#config_cache:intro

### Decisions

The change was manually tested only since the Step is not prepared for writing unit tests easily. I will create a follow-up ticket to make up for the missing test and to make the step testable.

With the manual test, I checked if the provided options are passed properly to the `gradlew dependencies` command:
- Updated the `sample` workflow to pass an addition gradlew dependencies option to the step:

```
...
    - path::./:
        title: Execute step
        inputs:
        - gradlew_dependencies_options: --configuration-cache-problems=warn
...
```
- Modified the step [here](https://github.com/bitrise-steplib/steps-install-missing-android-tools/blob/9988851ae38d2fdda30088be35b8b3247e9438ea/androidcomponents/androidcomponents.go#L117) to print the executed gradlew command:

```
func getDependenciesOutput(projectLocation string, options []string) (string, error) {
	args := []string{"dependencies", "--stacktrace"}
	args = append(args, options...)

	gradleCmd := command.New("./gradlew", args...)
	gradleCmd.SetStdin(strings.NewReader("y"))
	gradleCmd.SetDir(projectLocation)
	fmt.Println(gradleCmd.PrintableCommandArgs())
	return gradleCmd.RunAndReturnTrimmedCombinedOutput()
}
```
