### PR TITLE
Fix NDK path detection

### DIFF
--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -132,24 +132,6 @@ workflows:
         inputs:
         - gradle_task: assembleDebug
 
-  test_support_library:
-    envs:
-    - SAMPLE_APP_URL: https://github.com/bitrise-io/sample-apps-android-x.git
-    - BRANCH: master
-    - GRADLE_BUILD_FILE_PATH: build.gradle
-    - GRADLEW_PATH: ./gradlew
-    before_run:
-    - _setup
-    steps:
-    - script:
-        title: Uninstall Android SDK
-        inputs:
-        - content: |-
-            #!/usr/bin/env bash
-            sdkmanager --uninstall "extras;android;m2repository"
-    after_run:
-    - _run_and_build
-
   test_build_tools_not_installed:
     envs:
     - SAMPLE_APP_URL: https://github.com/bitrise-io/Bitrise-Android-Sample.git

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -209,6 +209,9 @@ workflows:
         - repository_url: $SAMPLE_APP_URL
         - clone_into_dir: .
         - branch: $BRANCH
+    - set-java-version:
+        inputs:
+        - java_version: "17"
 
   _run_and_build:
     steps:

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -173,24 +173,6 @@ workflows:
   _setup:
     steps:
     - script:
-        title: Enable JDK 11
-        description: This is still needed on the vs4mac stack
-        run_if: $.IsCI
-        inputs:
-        - content: |-
-            #!/usr/bin/env bash
-            set -ex
-            if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-              sudo update-alternatives --set javac /usr/lib/jvm/java-11-openjdk-amd64/bin/javac
-              sudo update-alternatives --set java /usr/lib/jvm/java-11-openjdk-amd64/bin/java
-              export JAVA_HOME="/usr/lib/jvm/java-11-openjdk-amd64"
-              envman add --key JAVA_HOME --value "/usr/lib/jvm/java-11-openjdk-amd64"
-            elif [[ "$OSTYPE" == "darwin"* ]]; then
-              jenv global 11 || jenv global 11.0
-              export JAVA_HOME="$(jenv prefix)"
-              envman add --key JAVA_HOME --value "$(jenv prefix)"
-            fi
-    - script:
         title: Clean _tmp dir
         inputs:
         - content: |-

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -209,9 +209,6 @@ workflows:
         - repository_url: $SAMPLE_APP_URL
         - clone_into_dir: .
         - branch: $BRANCH
-    - set-java-version:
-        inputs:
-        - java_version: "11"
 
   _run_and_build:
     steps:

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -209,6 +209,9 @@ workflows:
         - repository_url: $SAMPLE_APP_URL
         - clone_into_dir: .
         - branch: $BRANCH
+    - set-java-version:
+        inputs:
+        - java_version: "11"
 
   _run_and_build:
     steps:

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -238,6 +238,10 @@ workflows:
             #!/usr/bin/env bash
             set -ex
 
+            # If there is no ndk-bundle (only side-by-side NDKs), we don't need to back it up
+            if [ ! -d $ANDROID_HOME/ndk-bundle ]; then
+              exit 0
+            fi
             cp -R $ANDROID_HOME/ndk-bundle $ANDROID_HOME/ndk-bundle-original
 
   _restore_ndk_bundle:

--- a/e2e/bitrise.yml
+++ b/e2e/bitrise.yml
@@ -193,7 +193,7 @@ workflows:
         - branch: $BRANCH
     - set-java-version:
         inputs:
-        - java_version: "17"
+        - set_java_version: "17"
 
   _run_and_build:
     steps:

--- a/main.go
+++ b/main.go
@@ -175,7 +175,8 @@ func ndkVersion(ndkPath string) string {
 	return ""
 }
 
-// targetNDKPath picks the correct path where the requested NDK version should be installed.
+// targetNDKPath picks the correct path where the requested NDK version should be installed,
+// as well as returning if the path needs to be cleaned up before install.
 // There are many (deprecated) ways to install NDK, the logic is based on the following:
 // https://github.com/android/ndk-samples/wiki/Configure-NDK-Path
 // https://developer.android.com/tools/variables

--- a/main.go
+++ b/main.go
@@ -120,14 +120,14 @@ func (i AndroidToolsInstaller) Run(config Config) error {
 		}
 
 		if err := updateNDK(config.NDKVersion, androidSdk); err != nil {
-			return fmt.Errorf("failed to install new NDK package: %w", err)
+			return fmt.Errorf("install new NDK package: %w", err)
 		}
 	} else {
 		log.Infof("Clearing NDK environment")
 		log.Printf("Unset ANDROID_NDK_HOME")
 
 		if err := os.Unsetenv("ANDROID_NDK_HOME"); err != nil {
-			return fmt.Errorf("failed to unset environment variable: %w", err)
+			return fmt.Errorf("unset environment variable: %w", err)
 		}
 
 		if err := tools.ExportEnvironmentWithEnvman("ANDROID_NDK_HOME", ""); err != nil {
@@ -235,17 +235,17 @@ func updateNDK(version string, androidSdk *sdk.Model) error {
 	}
 	log.Printf("Done")
 
-	log.Printf("Installing NDK %s with sdkmanager", version)
+	log.Printf("Installing NDK %s with sdkmanager", colorstring.Cyan(version))
 	sdkManager, err := sdkmanager.New(androidSdk)
 	if err != nil {
 		return err
 	}
 	ndkComponent := sdkcomponent.NDK{Version: version}
 	cmd := sdkManager.InstallCommand(ndkComponent)
-	output, err := cmd.RunAndReturnTrimmedOutput()
+	output, err := cmd.RunAndReturnTrimmedCombinedOutput()
 	if err != nil {
 		log.Errorf(output)
-		return err
+		return fmt.Errorf("run %s: %w", cmd.PrintableCommandArgs(), err)
 	}
 	newNDKHome := filepath.Join(androidSdk.GetAndroidHome(), ndkComponent.InstallPathInAndroidHome())
 

--- a/main_test.go
+++ b/main_test.go
@@ -2,9 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/fs"
 	"testing"
-	"testing/fstest"
 
 	"github.com/stretchr/testify/require"
 )
@@ -13,122 +11,85 @@ func Test_currentNDKHome(t *testing.T) {
 	type test struct {
 		name string
 		envs map[string]string
-		fs   fs.FS
 		wantPath string
 		wantCleanup bool
 	}
 
 	requestedNDKVersion := "23.0.7599858"
-	// Note: the initial / is omitted in all paths below because of the limitation of fstest.MapFS:
-	// https://github.com/golang/go/issues/51378
 	tests := []test{
 		{
 			name: "ANDROID_NDK_HOME is set",
 			envs: map[string]string{
-				"ANDROID_NDK_HOME": "opt/android-ndk",
+				"ANDROID_NDK_HOME": "/opt/android-ndk",
 			},
-			fs: fstest.MapFS{
-				"opt/android-ndk/source.properties": &fstest.MapFile{
-					Data: []byte("Pkg.Revision = " + requestedNDKVersion),
-				},
+			wantPath: "/opt/android-ndk",
+			wantCleanup: true,
+		},
+		{
+			name: "both ANDROID_NDK_HOME and ANDROID_HOME are set",
+			envs: map[string]string{
+				"ANDROID_NDK_HOME": "/opt/android-ndk",
+				"ANDROID_HOME": "/opt/android-sdk",
 			},
-			wantPath: "opt/android-ndk",
+			wantPath: "/opt/android-ndk",
 			wantCleanup: true,
 		},
 		{
 			name: "only ndk-bundle is installed",
 			envs: map[string]string{
-				"ANDROID_HOME": "home/user/android-sdk",
+				"ANDROID_HOME": "/home/user/android-sdk",
 			},
-			fs: fstest.MapFS{
-				"home/user/android-sdk/ndk-bundle/source.properties": &fstest.MapFile{
-					Data: []byte("Pkg.Revision = 22.1.7171670"),
-				},
-			},
-			wantPath: "home/user/android-sdk/ndk/23.0.7599858",
+			wantPath: "/home/user/android-sdk/ndk/23.0.7599858",
 			wantCleanup: false,
 		},
 		{
 			name: "ndk-bundle and side-by-side NDK is installed",
 			envs: map[string]string{
-				"ANDROID_HOME": "home/user/android-sdk",
+				"ANDROID_HOME": "/home/user/android-sdk",
 			},
-			fs: fstest.MapFS{
-				"home/user/android-sdk/ndk-bundle/source.properties": &fstest.MapFile{
-					Data: []byte("Pkg.Revision = 22.1.7171670"),
-				},
-				"home/user/android-sdk/ndk/23.0.7599858/source.properties": &fstest.MapFile{
-					Data: []byte("Pkg.Revision = " + requestedNDKVersion),
-				},
-			},
-			wantPath: "home/user/android-sdk/ndk/23.0.7599858",
+			wantPath: "/home/user/android-sdk/ndk/23.0.7599858",
 			wantCleanup: false,
 		},
 		{
 			name: "the exact requested side-by-side NDK is installed",
 			envs: map[string]string{
-				"ANDROID_HOME": "home/user/android-sdk",
+				"ANDROID_HOME": "/home/user/android-sdk",
 			},
-			fs: fstest.MapFS{
-				"home/user/android-sdk/ndk/" + requestedNDKVersion + "/source.properties": &fstest.MapFile{
-					Data: []byte("Pkg.Revision = " + requestedNDKVersion),
-				},
-			},
-			wantPath: "home/user/android-sdk/ndk/23.0.7599858",
+			wantPath: "/home/user/android-sdk/ndk/23.0.7599858",
 			wantCleanup: false,
 		},
 		{
 			name: "a different side-by-side NDK is installed than requested",
 			envs: map[string]string{
-				"ANDROID_HOME": "home/user/android-sdk",
+				"ANDROID_HOME": "/home/user/android-sdk",
 			},
-			fs: fstest.MapFS{
-				"home/user/android-sdk/ndk/22.1.7171670/source.properties": &fstest.MapFile{
-					Data: []byte("Pkg.Revision = 22.1.7171670"),
-				},
-			},
-			wantPath: "home/user/android-sdk/ndk/23.0.7599858",
+			wantPath: "/home/user/android-sdk/ndk/23.0.7599858",
 			wantCleanup: false,
 		},
 		{
 			name: "both ANDROID_HOME and SDK_ROOT are set, pointing to the same dir",
 			envs: map[string]string{
-				"ANDROID_HOME": "home/user/android-sdk",
-				"SDK_ROOT": "home/user/android-sdk",
+				"ANDROID_HOME": "/home/user/android-sdk",
+				"SDK_ROOT": "/home/user/android-sdk",
 			},
-			fs: fstest.MapFS{
-				"home/user/android-sdk/ndk/22.1.7171670/source.properties": &fstest.MapFile{
-					Data: []byte("Pkg.Revision = 22.1.7171670"),
-				},
-			},
-			wantPath: "home/user/android-sdk/ndk/23.0.7599858",
+			wantPath: "/home/user/android-sdk/ndk/23.0.7599858",
 			wantCleanup: false,
 		},
 		{
 			name: "both ANDROID_HOME and SDK_ROOT are set, pointing to different dirs",
 			envs: map[string]string{
-				"ANDROID_HOME": "home/user/android-sdk-home",
-				"ANDROID_SDK_ROOT": "home/user/android-sdk-root",
+				"ANDROID_HOME": "/home/user/android-sdk-home",
+				"ANDROID_SDK_ROOT": "/home/user/android-sdk-root",
 			},
-			fs: fstest.MapFS{
-				"home/user/android-sdk/ndk/22.1.7171670/source.properties": &fstest.MapFile{
-					Data: []byte("Pkg.Revision = 22.1.7171670"),
-				},
-			},
-			wantPath: "home/user/android-sdk-home/ndk/23.0.7599858",
+			wantPath: "/home/user/android-sdk-home/ndk/23.0.7599858",
 			wantCleanup: false,
 		},
 		{
 			name: "only SDK_ROOT is set",
 			envs: map[string]string{
-				"ANDROID_SDK_ROOT": "home/user/android-sdk-root",
+				"ANDROID_SDK_ROOT": "/home/user/android-sdk-root",
 			},
-			fs: fstest.MapFS{
-				"home/user/android-sdk/ndk/22.1.7171670/source.properties": &fstest.MapFile{
-					Data: []byte("Pkg.Revision = 22.1.7171670"),
-				},
-			},
-			wantPath: "home/user/android-sdk-root/ndk/23.0.7599858",
+			wantPath: "/home/user/android-sdk-root/ndk/23.0.7599858",
 			wantCleanup: false,
 		},
 	}
@@ -136,7 +97,7 @@ func Test_currentNDKHome(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			envRepo := fakeEnvRepo{envVars: tt.envs}
-			gotPath, gotCleanup := targetNDKPath(envRepo, tt.fs, requestedNDKVersion)
+			gotPath, gotCleanup := targetNDKPath(envRepo, requestedNDKVersion)
 			require.Equal(t, tt.wantPath, gotPath)
 			require.Equal(t, tt.wantCleanup, gotCleanup)
 		})

--- a/main_test.go
+++ b/main_test.go
@@ -90,6 +90,47 @@ func Test_currentNDKHome(t *testing.T) {
 			wantPath: "home/user/android-sdk/ndk/23.0.7599858",
 			wantCleanup: false,
 		},
+		{
+			name: "both ANDROID_HOME and SDK_ROOT are set, pointing to the same dir",
+			envs: map[string]string{
+				"ANDROID_HOME": "home/user/android-sdk",
+				"SDK_ROOT": "home/user/android-sdk",
+			},
+			fs: fstest.MapFS{
+				"home/user/android-sdk/ndk/22.1.7171670/source.properties": &fstest.MapFile{
+					Data: []byte("Pkg.Revision = 22.1.7171670"),
+				},
+			},
+			wantPath: "home/user/android-sdk/ndk/23.0.7599858",
+			wantCleanup: false,
+		},
+		{
+			name: "both ANDROID_HOME and SDK_ROOT are set, pointing to different dirs",
+			envs: map[string]string{
+				"ANDROID_HOME": "home/user/android-sdk-home",
+				"ANDROID_SDK_ROOT": "home/user/android-sdk-root",
+			},
+			fs: fstest.MapFS{
+				"home/user/android-sdk/ndk/22.1.7171670/source.properties": &fstest.MapFile{
+					Data: []byte("Pkg.Revision = 22.1.7171670"),
+				},
+			},
+			wantPath: "home/user/android-sdk-home/ndk/23.0.7599858",
+			wantCleanup: false,
+		},
+		{
+			name: "only SDK_ROOT is set",
+			envs: map[string]string{
+				"ANDROID_SDK_ROOT": "home/user/android-sdk-root",
+			},
+			fs: fstest.MapFS{
+				"home/user/android-sdk/ndk/22.1.7171670/source.properties": &fstest.MapFile{
+					Data: []byte("Pkg.Revision = 22.1.7171670"),
+				},
+			},
+			wantPath: "home/user/android-sdk-root/ndk/23.0.7599858",
+			wantCleanup: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"fmt"
+	"io/fs"
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_currentNDKHome(t *testing.T) {
+	type test struct {
+		name string
+		envs map[string]string
+		fs   fs.FS
+		wantPath string
+		wantCleanup bool
+	}
+
+	requestedNDKVersion := "23.0.7599858"
+	// Note: the initial / is omitted in all paths below because of the limitation of fstest.MapFS:
+	// https://github.com/golang/go/issues/51378
+	tests := []test{
+		{
+			name: "ANDROID_NDK_HOME is set",
+			envs: map[string]string{
+				"ANDROID_NDK_HOME": "opt/android-ndk",
+			},
+			fs: fstest.MapFS{
+				"opt/android-ndk/source.properties": &fstest.MapFile{
+					Data: []byte("Pkg.Revision = " + requestedNDKVersion),
+				},
+			},
+			wantPath: "opt/android-ndk",
+			wantCleanup: true,
+		},
+		{
+			name: "only ndk-bundle is installed",
+			envs: map[string]string{
+				"ANDROID_HOME": "home/user/android-sdk",
+			},
+			fs: fstest.MapFS{
+				"home/user/android-sdk/ndk-bundle/source.properties": &fstest.MapFile{
+					Data: []byte("Pkg.Revision = 22.1.7171670"),
+				},
+			},
+			wantPath: "home/user/android-sdk/ndk/23.0.7599858",
+			wantCleanup: false,
+		},
+		{
+			name: "ndk-bundle and side-by-side NDK is installed",
+			envs: map[string]string{
+				"ANDROID_HOME": "home/user/android-sdk",
+			},
+			fs: fstest.MapFS{
+				"home/user/android-sdk/ndk-bundle/source.properties": &fstest.MapFile{
+					Data: []byte("Pkg.Revision = 22.1.7171670"),
+				},
+				"home/user/android-sdk/ndk/23.0.7599858/source.properties": &fstest.MapFile{
+					Data: []byte("Pkg.Revision = " + requestedNDKVersion),
+				},
+			},
+			wantPath: "home/user/android-sdk/ndk/23.0.7599858",
+			wantCleanup: false,
+		},
+		{
+			name: "the exact requested side-by-side NDK is installed",
+			envs: map[string]string{
+				"ANDROID_HOME": "home/user/android-sdk",
+			},
+			fs: fstest.MapFS{
+				"home/user/android-sdk/ndk/" + requestedNDKVersion + "/source.properties": &fstest.MapFile{
+					Data: []byte("Pkg.Revision = " + requestedNDKVersion),
+				},
+			},
+			wantPath: "home/user/android-sdk/ndk/23.0.7599858",
+			wantCleanup: false,
+		},
+		{
+			name: "a different side-by-side NDK is installed than requested",
+			envs: map[string]string{
+				"ANDROID_HOME": "home/user/android-sdk",
+			},
+			fs: fstest.MapFS{
+				"home/user/android-sdk/ndk/22.1.7171670/source.properties": &fstest.MapFile{
+					Data: []byte("Pkg.Revision = 22.1.7171670"),
+				},
+			},
+			wantPath: "home/user/android-sdk/ndk/23.0.7599858",
+			wantCleanup: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			envRepo := fakeEnvRepo{envVars: tt.envs}
+			gotPath, gotCleanup := targetNDKPath(envRepo, tt.fs, requestedNDKVersion)
+			require.Equal(t, tt.wantPath, gotPath)
+			require.Equal(t, tt.wantCleanup, gotCleanup)
+		})
+	}
+
+}
+
+type fakeEnvRepo struct {
+	envVars map[string]string
+}
+
+func (repo fakeEnvRepo) Get(key string) string {
+	value, ok := repo.envVars[key]
+	if ok {
+		return value
+	} else {
+		return ""
+	}
+}
+
+func (repo fakeEnvRepo) Set(key, value string) error {
+	repo.envVars[key] = value
+	return nil
+}
+
+func (repo fakeEnvRepo) Unset(key string) error {
+	repo.envVars[key] = ""
+	return nil
+}
+
+func (repo fakeEnvRepo) List() []string {
+	envs := []string{}
+	for k, v := range repo.envVars {
+		envs = append(envs, fmt.Sprintf("%s=%s", k, v))
+	}
+	return envs
+}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a PATCH [version update](https://semver.org/)

### Context

NDK installation and configuration has changed a lot over the years: https://github.com/android/ndk-samples/wiki/Configure-NDK-Path#the-default-ndk-location

It's also installed incorrectly on the Ubuntu 20 stack, which we fixed on Ubuntu 22. This in turn broke this step, which assumed the incorrect install location of the Ubuntu 20 stack (see #102)

### Changes

Clean up and rework the NDK location detection logic. I tried to comment the code as much as possible to preserve the reasoning.

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
