### PR TITLE
chore: bump bitrise-build-cache CLI to v2.3.1

### DIFF
--- a/buildcache/cli.go
+++ b/buildcache/cli.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	cliVersion       = "v2.0.2"
+	cliVersion       = "v2.3.1"
 	installerURL     = "https://raw.githubusercontent.com/bitrise-io/bitrise-build-cache-cli/main/install/installer.sh"
 	artifactRegistry = "https://artifactregistry.googleapis.com/download/v1/projects/ip-build-cache-prod/locations/us-central1/repositories/build-cache-cli-releases/files"
 )


### PR DESCRIPTION
## Summary

Bumps the pinned `bitrise-build-cache` CLI version from `v2.0.2` to `v2.3.1` in `buildcache/cli.go`.

The new CLI version brings improvements to the Maven repository mirror used by `activate gradle-mirrors`:

- Adds the `apache-central` Bitrise-hosted mirror for `https://repo.maven.apache.org/maven2`, matched by URL so explicit `maven { url = ... }` declarations are also redirected.
- Applies the apache-central mirror to `pluginManagement.repositories` (via prepend in `gradle.beforeSettings` + eager `.all` rewrite), so plugin resolution doesn't bypass the mirror.
- Routes the bitrise initd init script's `initscript { repositories { } }` classpath through the apache-central mirror when `BITRISE_MAVENCENTRAL_PROXY_ENABLED=true`, avoiding apache rate-limiting on `io.bitrise.gradle:*` resolution.

See bitrise-io/bitrise-build-cache-cli#291 for the underlying PR.

## Test plan

- [ ] Step CI green