### PR TITLE
chore: bump bitrise-build-cache CLI to v2.3.2

### DIFF
--- a/buildcache/cli.go
+++ b/buildcache/cli.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	cliVersion       = "v2.0.2"
+	cliVersion       = "v2.3.2"
 	installerURL     = "https://raw.githubusercontent.com/bitrise-io/bitrise-build-cache-cli/main/install/installer.sh"
 	artifactRegistry = "https://artifactregistry.googleapis.com/download/v1/projects/ip-build-cache-prod/locations/us-central1/repositories/build-cache-cli-releases/files"
 )


### PR DESCRIPTION
## Summary

Bumps the pinned `bitrise-build-cache` CLI from `v2.0.2` to `v2.3.2` in `buildcache/cli.go`.

The new CLI version improves the Maven repository mirror used by `activate gradle-mirrors`:

- **apache-central mirror** for `https://repo.maven.apache.org/maven2` (routes to the `/maven/apache-central` segment), matched by URL so explicit `maven { url = ... }` declarations are also redirected. Applied to `pluginManagement.repositories` as well.
- **mavencentral entry now dual-matches by name AND legacy URL** — `https://repo1.maven.org/maven2` declarations are now redirected to `/maven/central`. This unblocks projects (and older Gradle versions) that hit the legacy Maven Central host directly and 429-rate-limit (the actual failure mode this repo's e2e was hitting on the v2.3.1 attempt).
- **`io.bitrise.gradle:*` classpath** in the bitrise-build-cache init script now resolves through a new Bitrise `/gradle-plugins` mirror segment proxying `https://plugins.gradle.org/m2/`, avoiding the plugins.gradle.org → apache redirect chain that was 429-rate-limiting at scale.

See bitrise-io/bitrise-build-cache-cli#291 and bitrise-io/bitrise-build-cache-cli#292 for the underlying changes.

Replaces #113 (which targeted v2.3.1; that release's binaries were never published due to the verification step failure that v2.3.2 fixes).

## Test plan

- [ ] Step CI green (e2e test against the sample project should now redirect `repo1.maven.org/maven2` requests through `/maven/central`)