### PR TITLE
chore: bump bitrise-build-cache CLI to v2.3.3

### DIFF
--- a/buildcache/cli.go
+++ b/buildcache/cli.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	cliVersion       = "v2.0.2"
+	cliVersion       = "v2.3.3"
 	installerURL     = "https://raw.githubusercontent.com/bitrise-io/bitrise-build-cache-cli/main/install/installer.sh"
 	artifactRegistry = "https://artifactregistry.googleapis.com/download/v1/projects/ip-build-cache-prod/locations/us-central1/repositories/build-cache-cli-releases/files"
 )


### PR DESCRIPTION
## Summary

Bumps the pinned `bitrise-build-cache` CLI from `v2.0.2` to `v2.3.3` in `buildcache/cli.go`.

The new CLI version improves the Maven repository mirror used by `activate gradle-mirrors`:

- **apache-central mirror** for `https://repo.maven.apache.org/maven2` (routes to `/maven/apache-central`), matched by URL so explicit `maven { url = ... }` declarations are also redirected. Applied to `pluginManagement.repositories` as well.
- **mavencentral entry** now matches by name AND legacy URLs — `https://repo1.maven.org/maven2` (older Gradle / older project declarations) and `https://jcenter.bintray.com` (jcenter, sunset and now 302-redirecting to repo1.maven.org). All routed through `/maven/central`. This unblocks samples that hit `repo1.maven.org` and `jcenter.bintray.com` and 429-rate-limit (the failure mode the e2e test for this step was hitting).
- **`io.bitrise.gradle:*` classpath** in the bitrise-build-cache init script now resolves through a new Bitrise `/gradle-plugins` mirror segment proxying `https://plugins.gradle.org/m2/`, avoiding the plugins.gradle.org → apache redirect chain that was 429-rate-limiting at scale.

See bitrise-io/bitrise-build-cache-cli#291, #292, and #293 for the underlying changes.

Replaces #114 (which targeted v2.3.2; the e2e test was still hitting `jcenter()` which v2.3.3 addresses).

## Test plan

- [ ] Step CI green