### PR TITLE
chore: bump bitrise-build-cache CLI to v2.3.4

### DIFF
--- a/buildcache/cli.go
+++ b/buildcache/cli.go
@@ -15,7 +15,7 @@ import (
 )
 
 const (
-	cliVersion       = "v2.3.3"
+	cliVersion       = "v2.3.4"
 	installerURL     = "https://raw.githubusercontent.com/bitrise-io/bitrise-build-cache-cli/main/install/installer.sh"
 	artifactRegistry = "https://artifactregistry.googleapis.com/download/v1/projects/ip-build-cache-prod/locations/us-central1/repositories/build-cache-cli-releases/files"
 )


### PR DESCRIPTION
## Summary

Bumps the pinned `bitrise-build-cache` CLI from `v2.3.3` to `v2.3.4`.

The new CLI version fixes a regression in v2.3.1+ where the gradle-mirrors init script suppressed Gradle's default `pluginManagement.repositories = [gradlePluginPortal()]` for projects without an explicit `pluginManagement {}` block in `settings.gradle.kts`. This broke plugin resolution for plugins that only live on plugins.gradle.org:
- `org.gradle.toolchains.foojay-resolver-convention` (React Native projects)
- `io.invertase.gradle.build` (React Native Firebase)
- `org.gradle.kotlin.kotlin-dsl` (build-logic / `plugins/` modules)

Hit by hingehealth/phoenix and myfitnesspal/mfp-android on this CLI version. v2.3.4 re-adds `gradlePluginPortal()` after the mirror prepend (Gradle dedupes by repo name, so it's a no-op when projects already declare it).

See bitrise-io/bitrise-build-cache-cli#294.

## Test plan

- [ ] Step CI green
- [ ] Verify on consumer projects that plugin resolution succeeds