### PR TITLE
chore: bump bitrise-build-cache-cli to v2.4.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/bitrise-steplib/steps-install-missing-android-tools
 go 1.24.0
 
 require (
-	github.com/bitrise-io/bitrise-build-cache-cli/v2 v2.4.4
+	github.com/bitrise-io/bitrise-build-cache-cli/v2 v2.4.7
 	github.com/bitrise-io/go-android v1.0.0
 	github.com/bitrise-io/go-steputils v1.0.1
 	github.com/bitrise-io/go-utils v1.0.13

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/bitrise-io/bitrise-build-cache-cli/v2 v2.4.4 h1:fbaOQM+xvQekN9YRKx5njhdHLh7QNlgH+Q9YM33E+04=
-github.com/bitrise-io/bitrise-build-cache-cli/v2 v2.4.4/go.mod h1:6LH9KAREtVpZn5FWvo7YEd+d6cz3McEKag4NvmiuQU0=
+github.com/bitrise-io/bitrise-build-cache-cli/v2 v2.4.7 h1:kjGZg8JIj5dhukBHnHKcUc5RyTvxhRLLE3biKn+ezdQ=
+github.com/bitrise-io/bitrise-build-cache-cli/v2 v2.4.7/go.mod h1:6LH9KAREtVpZn5FWvo7YEd+d6cz3McEKag4NvmiuQU0=
 github.com/bitrise-io/go-android v1.0.0 h1:lP8O1rvoxKqly4XhN+zf7VhsKl9qvF4YrX45JzS4Z04=
 github.com/bitrise-io/go-android v1.0.0/go.mod h1:gGXmY8hJ1x44AC98TIvZZvxP7o+hs4VI6wgmO4JMfEg=
 github.com/bitrise-io/go-steputils v0.0.0-20210514150206-5b6261447e77/go.mod h1:H0iZjgsAR5NA6pnlD/zKB6AbxEsskq55pwJ9klVmP8w=

--- a/vendor/github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common/auth.go
+++ b/vendor/github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common/auth.go
@@ -1,0 +1,128 @@
+package common
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+var (
+	ErrAuthTokenNotProvided   = errors.New("BITRISE_BUILD_CACHE_AUTH_TOKEN or BITRISEIO_BITRISE_SERVICES_ACCESS_TOKEN environment variable not set")
+	ErrWorkspaceIDNotProvided = errors.New("BITRISE_BUILD_CACHE_WORKSPACE_ID environment variable not set")
+)
+
+// CacheAuthConfig holds the auth config for the cache.
+type CacheAuthConfig struct {
+	AuthToken   string
+	WorkspaceID string
+	IsJWT       bool
+}
+
+// TokenInGradleFormat returns the auth token in gradle format.
+// For JWT tokens, the token is sent as-is (the workspace ID is embedded in the JWT).
+// For PAT tokens, the format is "workspaceID:token".
+func (cac CacheAuthConfig) TokenInGradleFormat() string {
+	if cac.IsJWT || cac.WorkspaceID == "" {
+		return cac.AuthToken
+	}
+
+	return cac.WorkspaceID + ":" + cac.AuthToken
+}
+
+// ReadAuthConfigFromEnvironments reads auth information from the environment variables
+func ReadAuthConfigFromEnvironments(envs map[string]string) (CacheAuthConfig, error) {
+	authTokenEnv := envs["BITRISE_BUILD_CACHE_AUTH_TOKEN"]
+	workspaceIDEnv := envs["BITRISE_BUILD_CACHE_WORKSPACE_ID"]
+
+	if len(authTokenEnv) > 0 && len(workspaceIDEnv) > 0 {
+		return CacheAuthConfig{
+			AuthToken:   authTokenEnv,
+			WorkspaceID: workspaceIDEnv,
+		}, nil
+	}
+
+	// Try to fall back to JWT which is always available on Bitrise.
+	// It's a JWT token which already includes the workspace ID.
+	if serviceToken := envs["BITRISEIO_BITRISE_SERVICES_ACCESS_TOKEN"]; len(serviceToken) > 0 {
+		workspaceID, err := extractWorkspaceIDFromJWT(serviceToken)
+		if err != nil {
+			return CacheAuthConfig{}, fmt.Errorf("extract workspace ID from JWT: %w", err)
+		}
+
+		return CacheAuthConfig{
+			AuthToken:   serviceToken,
+			WorkspaceID: workspaceID,
+			IsJWT:       true,
+		}, nil
+	}
+
+	// Write specific errors for each case.
+	if len(authTokenEnv) < 1 {
+		return CacheAuthConfig{}, ErrAuthTokenNotProvided
+	}
+
+	return CacheAuthConfig{}, ErrWorkspaceIDNotProvided
+}
+
+// jwtPermissionClaims represents the claims within a UMA permission entry.
+type jwtPermissionClaims struct {
+	OrgID []string `json:"org_id"`
+}
+
+// jwtPermission represents a single permission entry in the authorization block.
+type jwtPermission struct {
+	Rsname string              `json:"rsname"`
+	Claims jwtPermissionClaims `json:"claims"`
+}
+
+// jwtAuthorization represents the authorization block in the JWT payload.
+type jwtAuthorization struct {
+	Permissions []jwtPermission `json:"permissions"`
+}
+
+// jwtPayload represents the JWT payload structure with UMA authorization permissions.
+type jwtPayload struct {
+	Authorization jwtAuthorization `json:"authorization"`
+}
+
+// extractWorkspaceIDFromJWT extracts the workspace ID (org_id) from a Bitrise JWT token
+// without validating the token signature.
+// The JWT uses UMA-style authorization permissions where org_id is a claim
+// inside the "default" resource permission.
+func extractWorkspaceIDFromJWT(token string) (string, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 { //nolint:mnd
+		return "", errors.New("invalid JWT format")
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", fmt.Errorf("decode JWT payload: %w", err)
+	}
+
+	var claims jwtPayload
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return "", fmt.Errorf("parse JWT payload: %w", err)
+	}
+
+	for _, perm := range claims.Authorization.Permissions {
+		if perm.Rsname != "default" {
+			continue
+		}
+
+		if len(perm.Claims.OrgID) == 0 {
+			return "", errors.New("org_id claim is missing from JWT")
+		}
+
+		workspaceID := perm.Claims.OrgID[0]
+		if workspaceID == "" {
+			return "", errors.New("org_id claim is empty in JWT")
+		}
+
+		return workspaceID, nil
+	}
+
+	return "", errors.New("'default' permission not found in JWT")
+}

--- a/vendor/github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common/benchmark.go
+++ b/vendor/github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common/benchmark.go
@@ -1,0 +1,200 @@
+package common
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/bitrise-io/go-utils/v2/log"
+	"github.com/bitrise-io/go-utils/v2/retryhttp"
+	"github.com/hashicorp/go-retryablehttp"
+)
+
+const (
+	benchmarkMaxRetries = 3
+
+	BenchmarkPhaseBaseline = "baseline"
+	BenchmarkPhaseWarmup   = "warmup"
+
+	BuildToolGradle = "gradle"
+	BuildToolXcode  = "xcode"
+	BuildToolBazel  = "bazel"
+)
+
+type benchmarkResponse struct {
+	Phase string `json:"phase"`
+}
+
+//go:generate moq -rm -stub -pkg mocks -out ./mocks/benchmark_phase_provider.go . BenchmarkPhaseProvider
+
+// BenchmarkPhaseProvider fetches the benchmark phase for a build.
+type BenchmarkPhaseProvider interface {
+	GetBenchmarkPhase(buildTool string, metadata CacheConfigMetadata) (string, error)
+}
+
+// BenchmarkPhaseClient fetches the benchmark phase for a Gradle build from the Bitrise API.
+type BenchmarkPhaseClient struct {
+	httpClient *retryablehttp.Client
+	baseURL    string
+	authConfig CacheAuthConfig
+	logger     log.Logger
+}
+
+// NewBenchmarkPhaseClient creates a new BenchmarkPhaseClient.
+func NewBenchmarkPhaseClient(baseURL string, authConfig CacheAuthConfig, logger log.Logger) *BenchmarkPhaseClient {
+	httpClient := retryhttp.NewClient(logger)
+	httpClient.RetryMax = benchmarkMaxRetries
+	httpClient.HTTPClient.Timeout = 10 * time.Second
+
+	return &BenchmarkPhaseClient{
+		httpClient: httpClient,
+		baseURL:    baseURL,
+		authConfig: authConfig,
+		logger:     logger,
+	}
+}
+
+// GetBenchmarkPhase fetches the benchmark phase for the current build.
+// The buildTool parameter specifies the build tool (gradle, xcode, bazel).
+// Returns empty string if no benchmark phase is active or if the build can't be identified.
+func (c *BenchmarkPhaseClient) GetBenchmarkPhase(buildTool string, metadata CacheConfigMetadata) (string, error) {
+	params := url.Values{}
+
+	if c.authConfig.WorkspaceID == "" {
+		c.logger.Debugf("no workspace ID found, skipping benchmark phase check")
+
+		return "", nil
+	}
+
+	if metadata.CIProvider == CIProviderBitrise {
+		if metadata.BitriseAppID == "" || metadata.BitriseWorkflowName == "" {
+			c.logger.Debugf("no Bitrise metadata found, skipping benchmark phase check")
+
+			return "", nil
+		}
+		params.Set("app_slug", metadata.BitriseAppID)
+		params.Set("workflow_name", metadata.BitriseWorkflowName)
+	} else {
+		if metadata.ExternalAppID == "" || metadata.ExternalWorkflowName == "" {
+			c.logger.Debugf("no external IDs found, skipping benchmark phase check")
+
+			return "", nil
+		}
+		params.Set("external_app_id", metadata.ExternalAppID)
+		params.Set("external_workflow_name", metadata.ExternalWorkflowName)
+	}
+
+	requestURL := fmt.Sprintf("%s/build-cache/%s/invocations/%s/command_benchmark_status?%s",
+		c.baseURL, c.authConfig.WorkspaceID, buildTool, params.Encode())
+
+	req, err := retryablehttp.NewRequest(http.MethodGet, requestURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create HTTP request: %w", err)
+	}
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.authConfig.AuthToken))
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to perform HTTP request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(resp.Body)
+
+		return "", fmt.Errorf("HTTP %d: %s", resp.StatusCode, body)
+	}
+
+	var result benchmarkResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return "", fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return result.Phase, nil
+}
+
+// BenchmarkPhaseFile is the JSON structure for the benchmark phase file.
+type BenchmarkPhaseFile struct {
+	Phase string `json:"phase"`
+}
+
+// BenchmarkPhaseEnvVar returns the env var name for a build tool's benchmark phase,
+// e.g. "gradle" → "BITRISE_BUILD_CACHE_BENCHMARK_PHASE_GRADLE".
+func BenchmarkPhaseEnvVar(buildTool string) string {
+	return "BITRISE_BUILD_CACHE_BENCHMARK_PHASE_" + strings.ToUpper(buildTool)
+}
+
+// BenchmarkPhaseFilePath returns the path to the benchmark phase file for a build tool.
+func BenchmarkPhaseFilePath(buildTool string) (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("get home directory: %w", err)
+	}
+
+	return filepath.Join(homeDir, ".local", "state", "xcelerate", "benchmark", "benchmark-phase-"+buildTool+".json"), nil
+}
+
+// WriteBenchmarkPhaseFile writes the benchmark phase to a JSON file for the given build tool.
+func WriteBenchmarkPhaseFile(buildTool, phase string, logger log.Logger) {
+	filePath, err := BenchmarkPhaseFilePath(buildTool)
+	if err != nil {
+		logger.Debugf("Failed to get benchmark phase file path: %v", err)
+
+		return
+	}
+
+	dir := filepath.Dir(filePath)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		logger.Debugf("Failed to create benchmark phase dir: %v", err)
+
+		return
+	}
+
+	data, err := json.Marshal(BenchmarkPhaseFile{Phase: phase})
+	if err != nil {
+		logger.Debugf("Failed to marshal benchmark phase file: %v", err)
+
+		return
+	}
+
+	if err := os.WriteFile(filePath, data, 0o644); err != nil { //nolint:mnd,gosec
+		logger.Debugf("Failed to write benchmark phase file: %v", err)
+
+		return
+	}
+
+	logger.Debugf("Benchmark phase written to %s", filePath)
+}
+
+// ReadBenchmarkPhaseFile reads the benchmark phase from the JSON file for the given build tool.
+// Returns empty string if the file doesn't exist or can't be read.
+func ReadBenchmarkPhaseFile(buildTool string, logger log.Logger) string {
+	filePath, err := BenchmarkPhaseFilePath(buildTool)
+	if err != nil {
+		logger.Debugf("Failed to get benchmark phase file path: %v", err)
+
+		return ""
+	}
+
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		logger.Debugf("Failed to read benchmark phase file: %v", err)
+
+		return ""
+	}
+
+	var result BenchmarkPhaseFile
+	if err := json.Unmarshal(data, &result); err != nil {
+		logger.Debugf("Failed to unmarshal benchmark phase file: %v", err)
+
+		return ""
+	}
+
+	return result.Phase
+}

--- a/vendor/github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common/cache_config.go
+++ b/vendor/github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common/cache_config.go
@@ -1,0 +1,342 @@
+package common
+
+import (
+	"crypto/sha256"
+	"fmt"
+	"hash"
+	"maps"
+	"os"
+	"os/user"
+	"runtime"
+	"strconv"
+	"strings"
+
+	"github.com/bitrise-io/go-utils/v2/log"
+)
+
+type CacheConfigMetadata struct {
+	CIProvider   string
+	CLIVersion   string
+	RedactedEnvs map[string]string
+	HostMetadata HostMetadata
+	GitMetadata  GitMetadata
+	// BitriseCI specific
+	BitriseAppID           string
+	BitriseWorkflowName    string
+	BitriseBuildID         string
+	BitriseStepExecutionID string
+	Datacenter             string
+	// External CI identifiers (non-Bitrise CI providers)
+	ExternalAppID        string
+	ExternalBuildID      string
+	ExternalWorkflowName string
+	// BenchmarkPhase is the benchmark phase (baseline, warmup, etc.)
+	BenchmarkPhase string
+}
+
+const (
+	// CIProviderBitrise ...
+	CIProviderBitrise = "bitrise"
+	// CIProviderCircleCI ...
+	CIProviderCircleCI = "circle-ci"
+	// CIProviderGitHubActions ...
+	CIProviderGitHubActions = "github-actions"
+	// CIProviderGitLabCI ...
+	CIProviderGitLabCI = "gitlab-ci"
+
+	RedactorSeed = "BitriseBuildCacheRedactor"
+)
+
+type CommandFunc func(string, ...string) (string, error)
+
+func detectCIProvider(envs map[string]string) string {
+	// Check other CI providers first, so that Build Hub builds
+	// (which also set BITRISE_IO) detect the original CI provider.
+	if envs["CIRCLECI"] != "" {
+		// https://circleci.com/docs/variables/#built-in-environment-variables
+		return CIProviderCircleCI
+	}
+	if envs["GITHUB_ACTIONS"] != "" {
+		// https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
+		return CIProviderGitHubActions
+	}
+	if envs["GITLAB_CI"] == "true" {
+		// https://docs.gitlab.com/ci/variables/predefined_variables/
+		return CIProviderGitLabCI
+	}
+	if envs["BITRISE_IO"] != "" && envs["BITRISE_BUILD_SLUG"] != "" {
+		// https://devcenter.bitrise.io/en/references/available-environment-variables.html
+		// Build Hub sets BITRISE_IO but not BITRISE_BUILD_SLUG
+		return CIProviderBitrise
+	}
+
+	return ""
+}
+
+func detectExternalIDs(provider string, envs map[string]string) (string, string, string) {
+	switch provider {
+	case CIProviderCircleCI:
+		return envs["CIRCLE_PROJECT_REPONAME"], envs["CIRCLE_WORKFLOW_ID"], envs["CIRCLE_JOB"]
+	case CIProviderGitHubActions:
+		return envs["GITHUB_REPOSITORY"], envs["GITHUB_RUN_ID"], envs["GITHUB_JOB"]
+	case CIProviderGitLabCI:
+		return envs["CI_PROJECT_PATH"], envs["CI_PIPELINE_ID"], envs["CI_JOB_NAME"]
+	default:
+		return "", "", ""
+	}
+}
+
+// HostMetadata contains metadata about the local environment. Only used for Bazel to
+// generate bazelrc. For Gradle, it's done by the plugin dynamically.
+type HostMetadata struct {
+	OS             string
+	CPUCores       int
+	MemSize        int64
+	Locale         string
+	DefaultCharset string
+	Hostname       string
+	Username       string
+}
+
+type GitMetadata struct {
+	RepoURL     string
+	CommitHash  string
+	Branch      string
+	CommitEmail string
+}
+
+// NewMetadata creates a new CacheConfigMetadata instance based on the environment variables.
+func NewMetadata(envs map[string]string, commandFunc CommandFunc, logger log.Logger) CacheConfigMetadata {
+	hostMetadata := generateHostMetadata(envs, commandFunc, logger)
+	git := generateGitMetadata(logger, commandFunc, envs)
+
+	cliVersion := GetCLIVersion(logger)
+
+	provider := detectCIProvider(envs)
+
+	redactedEnvs := maps.Clone(envs)
+	redactBitriseEnvs(redactedEnvs)
+
+	if provider == CIProviderBitrise {
+		return CacheConfigMetadata{
+			RedactedEnvs:           redactedEnvs,
+			CIProvider:             provider,
+			CLIVersion:             cliVersion,
+			GitMetadata:            git,
+			HostMetadata:           hostMetadata,
+			BitriseAppID:           envs["BITRISE_APP_SLUG"],
+			BitriseWorkflowName:    envs["BITRISE_TRIGGERED_WORKFLOW_ID"],
+			BitriseBuildID:         envs["BITRISE_BUILD_SLUG"],
+			BitriseStepExecutionID: envs["BITRISE_STEP_EXECUTION_ID"],
+			Datacenter:             envs[datacenterEnvKey],
+		}
+	}
+
+	externalAppID, externalBuildID, externalWorkflowName := detectExternalIDs(provider, envs)
+
+	return CacheConfigMetadata{
+		RedactedEnvs:         redactedEnvs,
+		CIProvider:           provider,
+		CLIVersion:           cliVersion,
+		GitMetadata:          git,
+		HostMetadata:         hostMetadata,
+		ExternalAppID:        externalAppID,
+		ExternalBuildID:      externalBuildID,
+		ExternalWorkflowName: externalWorkflowName,
+	}
+}
+
+func hashKeyValue(hasher hash.Hash, key, value string) []byte {
+	hasher.Reset()
+	hasher.Write([]byte(RedactorSeed))
+	hasher.Write([]byte(key))
+	hasher.Write([]byte(value))
+	hasher.Write([]byte(RedactorSeed))
+
+	return hasher.Sum(nil)
+}
+
+func redactBitriseEnvs(envs map[string]string) {
+	secretKeys := envs["BITRISE_SECRET_ENV_KEY_LIST"]
+	secretKeyList := strings.Split(secretKeys, ",")
+	hasher := sha256.New()
+	for _, key := range secretKeyList {
+		if key == "" {
+			continue
+		}
+		if envValue, ok := envs[key]; ok {
+			envs[key] = fmt.Sprintf("<sha256@%x>", hashKeyValue(hasher, key, envValue)[:4])
+		}
+	}
+
+	key := "BITRISE_BUILD_CACHE_AUTH_TOKEN"
+	if envValue, ok := envs[key]; ok {
+		envs[key] = fmt.Sprintf("<sha256@%x>", hashKeyValue(hasher, key, envValue)[:4])
+	}
+}
+
+func generateGitMetadata(logger log.Logger, commandFunc CommandFunc, envs map[string]string) GitMetadata {
+	gitMetadata := GitMetadata{}
+
+	// Repo URL
+	repoURL, err := commandFunc("git", "config", "--get", "remote.origin.url")
+	if err != nil {
+		logger.Debugf("Error in get git repo URL: %v", err)
+		repoURL = envs["GIT_REPOSITORY_URL"]
+	}
+	gitMetadata.RepoURL = strings.TrimSpace(repoURL)
+
+	// Commit hash
+	commitHash, err := commandFunc("git", "rev-parse", "HEAD")
+	if err != nil {
+		logger.Debugf("Error in get git commit hash: %v", err)
+		commitHash = envs["GIT_CLONE_COMMIT_HASH"]
+	}
+	gitMetadata.CommitHash = strings.TrimSpace(commitHash)
+
+	// Branch
+	branch := envs["BITRISE_GIT_BRANCH"]
+	if branch == "" {
+		branch, err = commandFunc("git", "branch", "--show-current")
+		if err != nil {
+			logger.Debugf("Error in get git branch: %v", err)
+		}
+	}
+	if branch == "" {
+		logger.Debugf("HEAD is probably detached, finding matching branches...")
+		branch, err = commandFunc("sh", "-c", "git branch --contains HEAD --format='%(refname:short)' | grep -v HEAD")
+		if err != nil {
+			logger.Debugf("Error in get git branch (2nd attempt): %v", err)
+		} else {
+			matchingBranches := strings.Split(branch, "\n")
+			if len(matchingBranches) == 1 {
+				// Only if there's a single matching branch, otherwise leave empty to avoid confusion
+				branch = matchingBranches[0]
+			}
+		}
+	}
+	branch = strings.TrimSpace(branch)
+	if branch != "" {
+		logger.Debugf("Detected git branch: %s", branch)
+	}
+	gitMetadata.Branch = branch
+
+	// Commit email
+	commitEmail, err := commandFunc("git", "show", "-s", "--format=%ae", gitMetadata.CommitHash)
+	if err != nil {
+		logger.Debugf("Error in get git commit email: %v", err)
+		commitEmail = envs["GIT_CLONE_COMMIT_AUTHOR_EMAIL"]
+	}
+	gitMetadata.CommitEmail = strings.TrimSpace(commitEmail)
+
+	return gitMetadata
+}
+
+// nolint: funlen, nestif
+func generateHostMetadata(envs map[string]string, commandFunc CommandFunc, logger log.Logger) HostMetadata {
+	metadata := HostMetadata{}
+
+	// OS
+	detectedOS, err := commandFunc("uname", "-a")
+	if err != nil {
+		logger.Errorf("Error in get OS: %v", err)
+	}
+	logger.Debugf("OS: %s", detectedOS)
+	metadata.OS = strings.TrimSpace(detectedOS)
+
+	// CPU cores
+	var ncpu int
+	if runtime.GOOS == "darwin" {
+		output, err := commandFunc("sysctl", "-n", "hw.ncpu")
+		if err != nil {
+			logger.Errorf("Error in get cpu cores: %v", err)
+		} else if len(output) > 0 {
+			ncpu, err = strconv.Atoi(strings.TrimSpace(output))
+			if err != nil {
+				logger.Errorf("Error in parse cpu cores: %v", err)
+			}
+		}
+	} else {
+		output, err := commandFunc("nproc")
+		if err != nil {
+			logger.Errorf("Error in get cpu cores: %v", err)
+		} else if len(output) > 0 {
+			ncpu, err = strconv.Atoi(strings.TrimSpace(output))
+			if err != nil {
+				logger.Errorf("Error in parse cpu cores: %v", err)
+			}
+		}
+	}
+	logger.Debugf("CPU cores: %d", ncpu)
+	metadata.CPUCores = ncpu
+
+	// RAM
+	var memSize int64
+	if runtime.GOOS == "darwin" {
+		output, err := commandFunc("sysctl", "-n", "hw.memsize")
+		if err != nil {
+			logger.Errorf("Error in get mem size: %v", err)
+		} else if len(output) > 0 {
+			memSize, err = strconv.ParseInt(strings.TrimSpace(output), 10, 64)
+			if err != nil {
+				logger.Errorf("Error in parse mem size: %v", err)
+			}
+		}
+	} else {
+		output, err := commandFunc("sh", "-c",
+			"grep MemTotal /proc/meminfo | tr -s ' ' | cut -d ' ' -f 2")
+		if err != nil {
+			logger.Errorf("Error in get mem size: %v", err)
+		} else if len(output) > 0 {
+			memSizeStr := strings.TrimSpace(output)
+			memSize, err = strconv.ParseInt(memSizeStr, 10, 64)
+			if err != nil {
+				logger.Errorf("Error in parse mem size: %v", err)
+			} else {
+				memSize *= 1024 // Convert from KB to Bytes
+			}
+		}
+	}
+	logger.Debugf("Memory size: %d", memSize)
+	metadata.MemSize = memSize
+
+	// Locale
+	localeRaw := getLocale(envs)
+	localeComps := strings.Split(localeRaw, ".")
+	if len(localeComps) == 2 {
+		metadata.Locale = localeComps[0]
+		metadata.DefaultCharset = localeComps[1]
+	}
+	logger.Debugf("Locale: %s", metadata.Locale)
+	logger.Debugf("Default charset: %s", metadata.DefaultCharset)
+
+	// Hostname
+	hostname, err := os.Hostname()
+	if err != nil {
+		logger.Errorf("Error in get hostname: %v", err)
+	}
+	metadata.Hostname = strings.TrimSpace(hostname)
+
+	// Username
+	u, err := user.Current()
+	if err != nil {
+		logger.Errorf("Error in get username: %v", err)
+	}
+	metadata.Username = strings.TrimSpace(u.Username)
+
+	return metadata
+}
+
+func getLocale(envs map[string]string) string {
+	// Check various environment variables for locale information
+	lang := envs["LANG"]
+	lcAll := envs["LC_ALL"]
+	if lcAll != "" {
+		return lcAll
+	}
+	if lang != "" {
+		return lang
+	}
+
+	return ""
+}

--- a/vendor/github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common/cli_version.go
+++ b/vendor/github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common/cli_version.go
@@ -1,0 +1,45 @@
+package common
+
+import (
+	"fmt"
+	"os"
+	"runtime/debug"
+	"slices"
+	"strings"
+
+	"github.com/bitrise-io/go-utils/v2/log"
+)
+
+func GetCLIVersion(logger log.Logger) string {
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		logger.Infof("Failed to read build info")
+
+		return "unknown"
+	}
+
+	// Find the bitrise-build-cache-cli module in the build info.
+	// If ran from source, it will be the main module.
+	// If ran from a step, it will be a dependency module.
+	modules := []*debug.Module{&bi.Main}
+	modules = append(modules, bi.Deps...)
+	idx := slices.IndexFunc(modules, func(c *debug.Module) bool { return strings.Contains(c.Path, "bitrise-build-cache-cli") })
+	if idx == -1 || idx >= len(modules) {
+		logger.Infof("Failed to find bitrise-build-cache-cli module in build info")
+
+		return "unknown"
+	}
+
+	return modules[idx].Version
+}
+
+// LogCLIVersion writes a single line with the resolved CLI version to STDERR.
+// Stderr (not stdout) is intentional: some callers — e.g. xcodebuild wrappers
+// fronted by `@react-native-community/cli-platform-apple` — parse the CLI's
+// stdout as JSON. Writing the version line to stdout breaks that JSON parse.
+// Call this from public entry points (cobra root PersistentPreRun, pkg/*
+// Activator/Runner methods) so each invocation records which CLI the caller
+// is running.
+func LogCLIVersion(logger log.Logger) {
+	_, _ = fmt.Fprintf(os.Stderr, "Bitrise Build Cache CLI version: %s\n", GetCLIVersion(logger))
+}

--- a/vendor/github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common/endpoint.go
+++ b/vendor/github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common/endpoint.go
@@ -1,0 +1,48 @@
+package common
+
+import (
+	"slices"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/consts"
+)
+
+const datacenterEnvKey = "BITRISE_DEN_VM_DATACENTER"
+
+//nolint:gochecknoglobals
+var (
+	// nonRBEDCs are datacenters where RBE is not available
+	nonRBEDCs = []string{
+		consts.USEAST1,
+	}
+)
+
+// SelectCacheEndpointURL - if endpointURL provided use that,
+// otherwise select the best build cache endpoint automatically
+func SelectCacheEndpointURL(endpointURL string, envs map[string]string) string {
+	if endpointURL == "" {
+		endpointURL = envs["BITRISE_BUILD_CACHE_ENDPOINT"]
+	}
+	if len(endpointURL) > 0 {
+		return endpointURL
+	}
+
+	return consts.BitriseAccelerate
+}
+
+// SelectRBEEndpointURL - if endpointURL provided use that,
+// otherwise select the RBE endpoint from environment
+func SelectRBEEndpointURL(endpointURL string, envs map[string]string) string {
+	if endpointURL == "" {
+		endpointURL = envs["BITRISE_RBE_ENDPOINT"]
+	}
+	if len(endpointURL) > 0 {
+		return endpointURL
+	}
+
+	bitriseDenVMDatacenter := envs[datacenterEnvKey]
+	if slices.Contains(nonRBEDCs, bitriseDenVMDatacenter) {
+		return ""
+	}
+
+	return consts.BitriseAccelerate
+}

--- a/vendor/github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/consts/consts.go
+++ b/vendor/github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/consts/consts.go
@@ -1,0 +1,36 @@
+package consts
+
+const (
+	IAD1    = "IAD1"
+	ORD1    = "ORD1"
+	USEAST1 = "US_EAST1"
+
+	// BitriseAccelerate currently pointing to IAD1, but in the same time, it's environment-aware.
+	// It points to the appropriate instance for the respective datacenter when used on VMs managed by Bitrise.
+	// More info: https://github.com/bitrise-io/build-prebooting-deployments/blob/production/preboot-reconciler/startup_script_extension_macos_bitvirt.sh#L72
+	BitriseAccelerate = "grpcs://bitrise-accelerate.services.bitrise.io"
+
+	XcodeAnalyticsServiceEndpoint         = "https://xcode-analytics.services.bitrise.io"
+	MultiplatformAnalyticsServiceEndpoint = "https://multiplatform-analytics.services.bitrise.io"
+
+	BitriseWebsiteBaseURL = "https://app.bitrise.io"
+
+	// Gradle Remote Build Cache related consts
+	GradleRemoteBuildCachePluginDepVersion = "1.3.3"
+
+	// Gradle Analytics related consts
+	GradleAnalyticsPluginDepVersion = "2.7.1"
+	GradleAnalyticsEndpoint         = "gradle-analytics.services.bitrise.io"
+	GradleAnalyticsPort             = 443
+	GradleAnalyticsHTTPEndpoint     = "https://gradle-sink.services.bitrise.io"
+	GradleAnalyticsGRPCEndpoint     = "grpcs://gradle-analytics.services.bitrise.io:444"
+
+	// Gradle Common Plugin version
+	GradleCommonPluginDepVersion = "1.0.7"
+
+	// Gradle Test Distribution Plugin version
+	GradleTestDistributionPluginDepVersion = "2.2.10"
+	GradleTestDistributionEndpoint         = "grpcs://bitrise-accelerate.services.bitrise.io"
+	GradleTestDistributionKvEndpoint       = "grpcs://bitrise-accelerate.services.bitrise.io"
+	GradleTestDistributionPort             = 443
+)

--- a/vendor/github.com/bitrise-io/bitrise-build-cache-cli/v2/pkg/gradle/mirrors/activator.go
+++ b/vendor/github.com/bitrise-io/bitrise-build-cache-cli/v2/pkg/gradle/mirrors/activator.go
@@ -10,6 +10,7 @@ import (
 	"github.com/bitrise-io/go-utils/v2/log"
 	"github.com/bitrise-io/go-utils/v2/pathutil"
 
+	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
 	mirrorsconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/gradle/mirrors"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
 )
@@ -116,6 +117,7 @@ func NewActivator(params ActivatorParams) *Activator {
 // env var), or when no datacenter is available, Activate logs the reason and
 // returns nil.
 func (a *Activator) Activate(_ context.Context) error {
+	configcommon.LogCLIVersion(a.logger)
 	a.logger.TInfof("Activate Bitrise mirrors for Gradle")
 
 	gradleHome, err := a.pathModifier.AbsPath(a.gradleHome)

--- a/vendor/github.com/bitrise-io/go-utils/v2/retryhttp/retryhttp.go
+++ b/vendor/github.com/bitrise-io/go-utils/v2/retryhttp/retryhttp.go
@@ -1,0 +1,25 @@
+package retryhttp
+
+import (
+	"github.com/bitrise-io/go-utils/v2/log"
+	"github.com/hashicorp/go-retryablehttp"
+)
+
+// NewClient returns a retryable HTTP client with common defaults
+func NewClient(logger log.Logger) *retryablehttp.Client {
+	client := retryablehttp.NewClient()
+	client.Logger = &httpLogAdaptor{logger: logger}
+	client.ErrorHandler = retryablehttp.PassthroughErrorHandler
+
+	return client
+}
+
+// httpLogAdaptor adapts the retryablehttp.Logger interface to the go-utils logger.
+type httpLogAdaptor struct {
+	logger log.Logger
+}
+
+// Printf implements the retryablehttp.Logger interface
+func (a *httpLogAdaptor) Printf(fmtStr string, vars ...interface{}) {
+	a.logger.Debugf(fmtStr, vars...)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,6 +1,8 @@
-# github.com/bitrise-io/bitrise-build-cache-cli/v2 v2.4.4
+# github.com/bitrise-io/bitrise-build-cache-cli/v2 v2.4.7
 ## explicit; go 1.24.0
+github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common
 github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/gradle/mirrors
+github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/consts
 github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/stringmerge
 github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils
 github.com/bitrise-io/bitrise-build-cache-cli/v2/pkg/gradle/mirrors
@@ -33,6 +35,7 @@ github.com/bitrise-io/go-utils/v2/exitcode
 github.com/bitrise-io/go-utils/v2/log
 github.com/bitrise-io/go-utils/v2/log/colorstring
 github.com/bitrise-io/go-utils/v2/pathutil
+github.com/bitrise-io/go-utils/v2/retryhttp
 # github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc
 ## explicit
 github.com/davecgh/go-spew/spew


### PR DESCRIPTION
Picks up ACI-4869: CLI version logging on every entry point. https://bitrise.atlassian.net/browse/ACI-4869

🤖 Generated with [Claude Code](https://claude.com/claude-code)