### PR TITLE
chore: bump bitrise-build-cache-cli to v2.4.9

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/bitrise-steplib/steps-install-missing-android-tools
 go 1.24.0
 
 require (
-	github.com/bitrise-io/bitrise-build-cache-cli/v2 v2.4.7
+	github.com/bitrise-io/bitrise-build-cache-cli/v2 v2.4.9
 	github.com/bitrise-io/go-android v1.0.0
 	github.com/bitrise-io/go-steputils v1.0.1
 	github.com/bitrise-io/go-utils v1.0.13

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/bitrise-io/bitrise-build-cache-cli/v2 v2.4.7 h1:kjGZg8JIj5dhukBHnHKcUc5RyTvxhRLLE3biKn+ezdQ=
-github.com/bitrise-io/bitrise-build-cache-cli/v2 v2.4.7/go.mod h1:6LH9KAREtVpZn5FWvo7YEd+d6cz3McEKag4NvmiuQU0=
+github.com/bitrise-io/bitrise-build-cache-cli/v2 v2.4.9 h1:jd3zZe9P+Z4hhrqXmOItY/yXxz3TQwszzDglDyHiwSo=
+github.com/bitrise-io/bitrise-build-cache-cli/v2 v2.4.9/go.mod h1:6LH9KAREtVpZn5FWvo7YEd+d6cz3McEKag4NvmiuQU0=
 github.com/bitrise-io/go-android v1.0.0 h1:lP8O1rvoxKqly4XhN+zf7VhsKl9qvF4YrX45JzS4Z04=
 github.com/bitrise-io/go-android v1.0.0/go.mod h1:gGXmY8hJ1x44AC98TIvZZvxP7o+hs4VI6wgmO4JMfEg=
 github.com/bitrise-io/go-steputils v0.0.0-20210514150206-5b6261447e77/go.mod h1:H0iZjgsAR5NA6pnlD/zKB6AbxEsskq55pwJ9klVmP8w=

--- a/vendor/github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/gradle/mirrors/activate.go
+++ b/vendor/github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/gradle/mirrors/activate.go
@@ -17,12 +17,26 @@ const EnabledEnvKey = "BITRISE_MAVENCENTRAL_PROXY_ENABLED"
 // DatacenterEnvKey identifies the Bitrise datacenter the build runs in.
 const DatacenterEnvKey = "BITRISE_DEN_VM_DATACENTER"
 
+// MirrorURLEnvKeyPrefix is the prefix for per-mirror URL env vars exported on
+// activation: `BITRISE_MAVENCENTRAL_PROXY_URL_<TemplateID>` (e.g.
+// `BITRISE_MAVENCENTRAL_PROXY_URL_ApacheCentral`).
+const MirrorURLEnvKeyPrefix = "BITRISE_MAVENCENTRAL_PROXY_URL_"
+
+// Exporter exports an env var for the rest of the workflow. Implemented by
+// internal/envexport.EnvExporter (sets process env, calls envman on Bitrise CI,
+// and writes to GITHUB_ENV on GitHub Actions).
+type Exporter interface {
+	Export(key, value string)
+}
+
 // Params bundles the inputs needed to write the Gradle mirrors init script.
 type Params struct {
-	GradleHome string       // absolute path to the Gradle home (e.g. ~/.gradle expanded)
-	Mirrors    []RepoMirror // mirrors to install
-	Datacenter string       // datacenter (e.g. "AMS1") used to build the mirror URL
-	Enabled    bool         // when false, Activate is a no-op
+	GradleHome  string       // absolute path to the Gradle home (e.g. ~/.gradle expanded)
+	Mirrors     []RepoMirror // mirrors to install
+	Datacenter  string       // datacenter (e.g. "AMS1") used to build the mirror URL
+	Enabled     bool         // when false, Activate is a no-op
+	ProjectRoot string       // project root scanned for scope-gap warnings; empty disables scanning
+	Exporter    Exporter     // when non-nil, exports BITRISE_MAVENCENTRAL_PROXY_URL_<ID> per activated mirror
 }
 
 type templateEntry struct {
@@ -102,6 +116,18 @@ func Activate(logger log.Logger, osProxy utils.OsProxy, params Params) error {
 	}
 
 	logger.Infof("Gradle mirrors activated")
+
+	if params.Exporter != nil {
+		for _, e := range entries {
+			key := MirrorURLEnvKeyPrefix + e.ID
+			params.Exporter.Export(key, e.MirrorURL)
+			logger.Debugf("Exported %s=%s", key, e.MirrorURL)
+		}
+	}
+
+	if params.ProjectRoot != "" {
+		LogScopeGapWarnings(logger, osProxy, params.ProjectRoot)
+	}
 
 	return nil
 }

--- a/vendor/github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/gradle/mirrors/mirror.go
+++ b/vendor/github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/gradle/mirrors/mirror.go
@@ -25,7 +25,6 @@ var KnownMirrors = []RepoMirror{ //nolint:gochecknoglobals
 	{FlagName: "mavencentral-apache", TemplateID: "ApacheCentral", URLSegment: "apache-central", GradleMatch: `r.getUrl().toString().trimEnd('/').equals("https://repo.maven.apache.org/maven2")`, ApplyToPluginManagement: true},
 	{FlagName: "mavencentral", TemplateID: "Central", URLSegment: "central", GradleMatch: `r.getName().equals(ArtifactRepositoryContainer.DEFAULT_MAVEN_CENTRAL_REPO_NAME) || r.getUrl().toString().trimEnd('/') in setOf("https://repo1.maven.org/maven2", "https://jcenter.bintray.com")`, UseAsRobolectricRepo: true},
 	{FlagName: "google", TemplateID: "Google", URLSegment: "google", GradleMatch: `r.getName().equals("Google")`},
-	{FlagName: "jitpack", TemplateID: "JitPack", URLSegment: "jitpack", GradleMatch: `r.getUrl().toString().trimEnd('/') in setOf("https://jitpack.io", "https://www.jitpack.io")`},
 	{FlagName: "gradle-plugin-portal", TemplateID: "PluginPortal", URLSegment: "gradle-plugins", GradleMatch: `r.getUrl().toString().trimEnd('/').equals("https://plugins.gradle.org/m2")`, ApplyToPluginManagement: true},
 }
 

--- a/vendor/github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/gradle/mirrors/scope_gap.go
+++ b/vendor/github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/gradle/mirrors/scope_gap.go
@@ -1,0 +1,74 @@
+package mirrors
+
+import (
+	"path/filepath"
+	"regexp"
+
+	"github.com/bitrise-io/go-utils/v2/log"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
+)
+
+// gradleScriptCandidates are the script files scanned at activation time.
+// We check the project root + the conventional Android `app/` module dir.
+// Anything declared inside `apply(from = ...)`-loaded scripts' own
+// buildscript {} blocks is invisible to the init script — those scripts'
+// ScriptHandler instances are not reachable from gradle.beforeSettings or
+// gradle.beforeProject hooks. Surfacing the file makes the gap actionable.
+//
+//nolint:gochecknoglobals
+var gradleScriptCandidates = []string{
+	"settings.gradle",
+	"settings.gradle.kts",
+	"build.gradle",
+	"build.gradle.kts",
+	filepath.Join("app", "build.gradle"),
+	filepath.Join("app", "build.gradle.kts"),
+}
+
+//nolint:gochecknoglobals
+var (
+	applyFromKotlinRe = regexp.MustCompile(`apply\s*\(\s*from\s*=`)
+	applyFromGroovyRe = regexp.MustCompile(`\bapply\s+from\s*:`)
+)
+
+// LogScopeGapWarnings scans the project for Gradle scripts that pull in other
+// scripts via `apply(from = ...)`. Repositories declared inside those applied
+// scripts' own buildscript {} blocks are not redirected by the mirror init
+// script, so dependencies they resolve still hit the upstream repo and may
+// fail with rate limits or verification mismatches.
+func LogScopeGapWarnings(logger log.Logger, osProxy utils.OsProxy, projectRoot string) {
+	hits := scanForApplyFrom(osProxy, projectRoot)
+	if len(hits) == 0 {
+		return
+	}
+
+	logger.Warnf("Detected %d Gradle script(s) using `apply(from = ...)`:", len(hits))
+
+	for _, h := range hits {
+		logger.Warnf("  - %s", h)
+	}
+
+	logger.Warnf("Bitrise repository mirrors do NOT cover repositories declared inside applied scripts' own buildscript {} blocks.")
+	logger.Warnf("If those scripts declare e.g. mavenCentral() in a buildscript {} block, dependencies fetched from there go to the upstream repo and may hit rate limits or verification failures.")
+	logger.Warnf("Recommended: move plugin classpath into settings.gradle.kts pluginManagement {}, which the mirror covers.")
+}
+
+func scanForApplyFrom(osProxy utils.OsProxy, projectRoot string) []string {
+	var hits []string
+
+	for _, name := range gradleScriptCandidates {
+		path := filepath.Join(projectRoot, name)
+
+		content, ok, err := osProxy.ReadFileIfExists(path)
+		if err != nil || !ok {
+			continue
+		}
+
+		if applyFromKotlinRe.MatchString(content) || applyFromGroovyRe.MatchString(content) {
+			hits = append(hits, path)
+		}
+	}
+
+	return hits
+}

--- a/vendor/github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/envexport/envexport.go
+++ b/vendor/github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/envexport/envexport.go
@@ -1,0 +1,119 @@
+package envexport
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/bitrise-io/go-utils/v2/log"
+
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/stringmerge"
+)
+
+// EnvExporter exports environment variables to the current process and CI-specific mechanisms.
+// It sets os env vars, calls envman (Bitrise CI), and writes to GITHUB_ENV (GitHub Actions).
+type EnvExporter struct {
+	envs   map[string]string
+	logger log.Logger
+}
+
+// New creates an EnvExporter. The envs map is used to read CI-specific file paths (e.g. GITHUB_ENV).
+func New(envs map[string]string, logger log.Logger) *EnvExporter {
+	return &EnvExporter{
+		envs:   envs,
+		logger: logger,
+	}
+}
+
+// Export sets the environment variable in the current process, calls envman for Bitrise CI,
+// and writes to the GITHUB_ENV file for GitHub Actions.
+// All errors are logged as debug and do not fail the caller.
+func (e *EnvExporter) Export(key, value string) {
+	if err := os.Setenv(key, value); err != nil {
+		e.logger.Debugf("Failed to set env var %s: %v", key, err)
+	}
+
+	e.exportViaEnvman(key, value)
+	e.exportViaGitHubEnv(key, value)
+}
+
+func (e *EnvExporter) exportViaEnvman(key, value string) {
+	output, err := exec.Command("envman", "add", //nolint:noctx
+		"--key", key,
+		"--value", value,
+	).CombinedOutput()
+	if err != nil {
+		e.logger.Debugf("Failed to export %s via envman: %s (%v)", key, string(output), err)
+	}
+}
+
+func (e *EnvExporter) exportViaGitHubEnv(key, value string) {
+	filePath := e.envs["GITHUB_ENV"]
+	if filePath == "" {
+		return
+	}
+
+	f, err := os.OpenFile(filePath, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0o644) //nolint:mnd
+	if err != nil {
+		e.logger.Debugf("Failed to open GITHUB_ENV file: %v", err)
+
+		return
+	}
+	defer f.Close()
+
+	writer := bufio.NewWriter(f)
+	if _, err := fmt.Fprintf(writer, "%s=%s\n", key, value); err != nil {
+		e.logger.Debugf("Failed to write to GITHUB_ENV file: %v", err)
+
+		return
+	}
+
+	if err := writer.Flush(); err != nil {
+		e.logger.Debugf("Failed to flush GITHUB_ENV file: %v", err)
+	}
+}
+
+// ExportToShellRC writes an export statement to ~/.bashrc and ~/.zshrc using a marker block.
+// The blockName identifies the block in the file (e.g. "Bitrise Build Cache").
+// The content is the raw shell content to write (e.g. "export KEY=VALUE").
+func (e *EnvExporter) ExportToShellRC(blockName, content string) {
+	homeDir := e.envs["HOME"]
+	if homeDir == "" {
+		var err error
+		homeDir, err = os.UserHomeDir()
+		if err != nil {
+			e.logger.Debugf("Failed to get home directory: %v", err)
+
+			return
+		}
+	}
+
+	for _, rcFile := range []string{".bashrc", ".zshrc"} {
+		rcPath := filepath.Join(homeDir, rcFile)
+		if err := writeShellRCBlock(rcPath, blockName, content); err != nil {
+			e.logger.Debugf("Failed to update %s: %v", rcFile, err)
+		}
+	}
+}
+
+func writeShellRCBlock(filePath, blockName, content string) error {
+	currentContent, err := os.ReadFile(filePath)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to read %s: %w", filePath, err)
+	}
+
+	newContent := stringmerge.ChangeContentInBlock(
+		string(currentContent),
+		fmt.Sprintf("# [start] %s", blockName),
+		fmt.Sprintf("# [end] %s", blockName),
+		content,
+	)
+
+	if err := os.WriteFile(filePath, []byte(newContent), 0o644); err != nil { //nolint:mnd,gosec
+		return fmt.Errorf("failed to write %s: %w", filePath, err)
+	}
+
+	return nil
+}

--- a/vendor/github.com/bitrise-io/bitrise-build-cache-cli/v2/pkg/gradle/mirrors/activator.go
+++ b/vendor/github.com/bitrise-io/bitrise-build-cache-cli/v2/pkg/gradle/mirrors/activator.go
@@ -12,6 +12,7 @@ import (
 
 	configcommon "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common"
 	mirrorsconfig "github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/gradle/mirrors"
+	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/envexport"
 	"github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils"
 )
 
@@ -27,6 +28,11 @@ type ActivatorParams struct {
 	// GradleHome is the Gradle home directory. Tilde-prefixed paths are expanded.
 	// Empty means DefaultGradleHome.
 	GradleHome string
+
+	// ProjectRoot is the directory scanned for scope-gap warnings (Gradle
+	// scripts using `apply(from = ...)`). Empty falls back to the current
+	// working directory; "-" disables scanning.
+	ProjectRoot string
 
 	// SelectedFlags lists the mirror flag names to enable (e.g. "mavencentral",
 	// "google"). Empty means all mirrors in mirrorsconfig.KnownMirrors.
@@ -66,6 +72,7 @@ type Activator struct {
 	pathModifier pathutil.PathModifier
 
 	gradleHome    string
+	projectRoot   string
 	selectedFlags []string
 	datacenter    string
 	enabled       *bool
@@ -105,6 +112,7 @@ func NewActivator(params ActivatorParams) *Activator {
 		pathModifier: pathModifier,
 
 		gradleHome:    gradleHome,
+		projectRoot:   params.ProjectRoot,
 		selectedFlags: params.SelectedFlags,
 		datacenter:    params.Datacenter,
 		enabled:       params.Enabled,
@@ -128,12 +136,15 @@ func (a *Activator) Activate(_ context.Context) error {
 	enabled := a.resolveEnabled()
 	datacenter := a.resolveDatacenter()
 	selected := mirrorsconfig.FilterByFlagNames(a.selectedFlags)
+	projectRoot := a.resolveProjectRoot()
 
 	if err := mirrorsconfig.Activate(a.logger, a.osProxy, mirrorsconfig.Params{
-		GradleHome: gradleHome,
-		Mirrors:    selected,
-		Datacenter: datacenter,
-		Enabled:    enabled,
+		GradleHome:  gradleHome,
+		Mirrors:     selected,
+		Datacenter:  datacenter,
+		Enabled:     enabled,
+		ProjectRoot: projectRoot,
+		Exporter:    envexport.New(a.envs, a.logger),
 	}); err != nil {
 		return fmt.Errorf("activate gradle mirrors: %w", err)
 	}
@@ -159,4 +170,22 @@ func (a *Activator) resolveDatacenter() string {
 	}
 
 	return a.envs[mirrorsconfig.DatacenterEnvKey]
+}
+
+func (a *Activator) resolveProjectRoot() string {
+	switch a.projectRoot {
+	case "-":
+		return ""
+	case "":
+		cwd, err := a.osProxy.Getwd()
+		if err != nil {
+			a.logger.Debugf("Could not determine working directory for scope-gap scan: %s", err)
+
+			return ""
+		}
+
+		return cwd
+	default:
+		return a.projectRoot
+	}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,8 +1,9 @@
-# github.com/bitrise-io/bitrise-build-cache-cli/v2 v2.4.7
+# github.com/bitrise-io/bitrise-build-cache-cli/v2 v2.4.9
 ## explicit; go 1.24.0
 github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common
 github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/gradle/mirrors
 github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/consts
+github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/envexport
 github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/stringmerge
 github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/utils
 github.com/bitrise-io/bitrise-build-cache-cli/v2/pkg/gradle/mirrors


### PR DESCRIPTION
Bump CLI dep to [v2.4.9](https://github.com/bitrise-io/bitrise-build-cache-cli/releases/tag/v2.4.9). Combines v2.4.8 (jitpack mirror disable, gradle-mirrors scope-gap activation-time warning) and v2.4.9 (per-mirror proxy URL env var export on activation).