### PR TITLE
chore: bump bitrise-build-cache-cli to v2.6.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,11 @@ module github.com/bitrise-steplib/steps-install-missing-android-tools
 go 1.24.0
 
 require (
-	github.com/bitrise-io/bitrise-build-cache-cli/v2 v2.5.0
+	github.com/bitrise-io/bitrise-build-cache-cli/v2 v2.6.0
 	github.com/bitrise-io/go-android v1.0.0
 	github.com/bitrise-io/go-steputils v1.0.1
 	github.com/bitrise-io/go-utils v1.0.13
-	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.27
+	github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.34
 	github.com/hashicorp/go-version v1.3.0
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/bitrise-io/bitrise-build-cache-cli/v2 v2.5.0 h1:H6sgX541H6ApmSP3iro921AdcPOMeX7Bk5HQ40nUNhA=
-github.com/bitrise-io/bitrise-build-cache-cli/v2 v2.5.0/go.mod h1:6LH9KAREtVpZn5FWvo7YEd+d6cz3McEKag4NvmiuQU0=
+github.com/bitrise-io/bitrise-build-cache-cli/v2 v2.6.0 h1:ggnskS2+gsKtANgZ5dmbqUDW0UgL9UmOoDF0+g60Ru4=
+github.com/bitrise-io/bitrise-build-cache-cli/v2 v2.6.0/go.mod h1:cBNHOK0ly1CsICg89/bG2hjC1qQ6OcWUwAii4ofbTJQ=
 github.com/bitrise-io/go-android v1.0.0 h1:lP8O1rvoxKqly4XhN+zf7VhsKl9qvF4YrX45JzS4Z04=
 github.com/bitrise-io/go-android v1.0.0/go.mod h1:gGXmY8hJ1x44AC98TIvZZvxP7o+hs4VI6wgmO4JMfEg=
 github.com/bitrise-io/go-steputils v0.0.0-20210514150206-5b6261447e77/go.mod h1:H0iZjgsAR5NA6pnlD/zKB6AbxEsskq55pwJ9klVmP8w=
@@ -10,8 +10,8 @@ github.com/bitrise-io/go-utils v0.0.0-20210520073355-367fa34178f5/go.mod h1:DRx7
 github.com/bitrise-io/go-utils v1.0.1/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
 github.com/bitrise-io/go-utils v1.0.13 h1:1QENhTS/JlKH9F7+/nB+TtbTcor6jGrE6cQ4CJWfp5U=
 github.com/bitrise-io/go-utils v1.0.13/go.mod h1:ZY1DI+fEpZuFpO9szgDeICM4QbqoWVt0RSY3tRI1heY=
-github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.27 h1:fB4ZZMZFF4xq9RwXRyB1x6Ty68pFFXSIZ0h/8FDZWmA=
-github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.27/go.mod h1:3XUplo0dOWc3DqT2XA2SeHToDSg7+j1y1HTHibT2H68=
+github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.34 h1:xsLfhItfs4SCCAesbv7UtKpldNqievDvtHggSuBI2+w=
+github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.34/go.mod h1:5Z/vkUZ2BIY7IAVlMGns3ypRjd+J872YBSCJaLWVo/U=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/vendor/github.com/bitrise-io/go-utils/v2/log/log.go
+++ b/vendor/github.com/bitrise-io/go-utils/v2/log/log.go
@@ -7,7 +7,8 @@ import (
 	"time"
 )
 
-// Logger ...
+// Logger interface designed to provide only the necessary functionality used by our tooling.
+// The lack of in-line printing is intentional.
 type Logger interface {
 	Infof(format string, v ...interface{})
 	Warnf(format string, v ...interface{})
@@ -152,7 +153,9 @@ func (l *logger) TErrorf(format string, v ...interface{}) {
 
 // Println ...
 func (l *logger) Println() {
-	fmt.Println()
+	if _, err := fmt.Fprintln(l.stdout); err != nil {
+		fmt.Printf("failed to print newline: %s\n", err)
+	}
 }
 
 func (l *logger) timestampField() string {
@@ -180,6 +183,6 @@ func (l *logger) createLogMsg(severity Severity, withTime bool, format string, v
 func (l *logger) printf(severity Severity, withTime bool, format string, v ...interface{}) {
 	message := l.createLogMsg(severity, withTime, format, v...)
 	if _, err := fmt.Fprintln(l.stdout, message); err != nil {
-		fmt.Printf("failed to print message: %s, error: %s\n", message, err)
+		fmt.Printf("failed to print message: %s: %s\n", message, err)
 	}
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/bitrise-io/bitrise-build-cache-cli/v2 v2.5.0
+# github.com/bitrise-io/bitrise-build-cache-cli/v2 v2.6.0
 ## explicit; go 1.24.0
 github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/common
 github.com/bitrise-io/bitrise-build-cache-cli/v2/internal/config/gradle/mirrors
@@ -27,8 +27,8 @@ github.com/bitrise-io/go-utils/pathutil
 github.com/bitrise-io/go-utils/pointers
 github.com/bitrise-io/go-utils/retry
 github.com/bitrise-io/go-utils/sliceutil
-# github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.27
-## explicit; go 1.17
+# github.com/bitrise-io/go-utils/v2 v2.0.0-alpha.34
+## explicit; go 1.21
 github.com/bitrise-io/go-utils/v2/command
 github.com/bitrise-io/go-utils/v2/env
 github.com/bitrise-io/go-utils/v2/errorutil


### PR DESCRIPTION
Bumps the embedded CLI dependency to v2.6.0.